### PR TITLE
fix(cuda): make CudaStorage generic over Scalar with runtime type dis…

### DIFF
--- a/src/backend/traits.rs
+++ b/src/backend/traits.rs
@@ -206,11 +206,6 @@ impl<T: Scalar> BackendScalar<crate::backend::Cpu> for T {}
 impl BackendScalar<crate::backend::Cuda> for f32 {}
 #[cfg(feature = "cuda")]
 impl BackendScalar<crate::backend::Cuda> for f64 {}
-#[cfg(feature = "cuda")]
-impl BackendScalar<crate::backend::Cuda> for crate::algebra::Complex32 {}
-#[cfg(feature = "cuda")]
-impl BackendScalar<crate::backend::Cuda> for crate::algebra::Complex64 {}
-#[cfg(feature = "cuda")]
-impl BackendScalar<crate::backend::Cuda> for crate::backend::CudaComplex<f32> {}
-#[cfg(feature = "cuda")]
-impl BackendScalar<crate::backend::Cuda> for crate::backend::CudaComplex<f64> {}
+// Note: CudaComplex types are handled internally but don't implement Scalar
+// Users should use f32/f64 for contractions, complex support via CudaComplex
+// is internal to the CUDA backend


### PR DESCRIPTION
…patch

- Change `Storage<T>` impl from `T: CudaScalar` to `T: Scalar` to satisfy Backend::Storage type bounds in generic contexts
- Add runtime type dispatch using TypeId for f32/f64/u32 operations
- Remove unused BackendScalar implementations for complex types
- This allows CudaStorage to be used in generic code while still only supporting f32/f64/u32 at runtime (with clear panic messages for unsupported types)

The previous implementation required CudaScalar bounds which couldn't be expressed in generic contexts where Backend::Storage<T> was used with just T: Scalar bounds.