### PR TITLE
feat: add omeinsum CLI workspace tool

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,11 +19,24 @@ make help
 make cargo-check
 make check
 make test
+make cli            # Build and install the omeinsum CLI to ~/.cargo/bin
 cargo test --test main
 cargo test --features tropical
 ```
 
 `make check` is the canonical pre-PR gate. It runs formatting, clippy, and the non-GPU test suite.
+
+## CLI (`omeinsum`)
+
+Install with `make cli`. Two subcommands:
+
+- **`omeinsum optimize`** — Optimize contraction order for an einsum expression.
+  `omeinsum optimize "ij,jk->ik" --sizes "i=2,j=3,k=4"` (methods: `greedy`, `treesa`).
+  Greedy accepts `--alpha`, `--temperature`. TreeSA accepts `--ntrials`, `--niters`,
+  `--betas`, `--sc-target`, `--tc-weight`, `--sc-weight`, `--rw-weight`.
+- **`omeinsum contract`** — Execute a tensor contraction from a tensors JSON file.
+  Requires either `--topology <file>` (from optimize) or `--expr "(ij,jk),kl->il"`.
+  Supported dtypes: f32, f64, c32, c64.
 
 ## Testing Conventions
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ dist/
 build/
 *.whl
 .worktrees/
+docs/superpowers/
+docs/test-reports/
+*.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,6 @@ required-features = ["tropical"]
 name = "tropical_network"
 path = "examples/tropical_network.rs"
 required-features = ["tropical"]
+
+[workspace]
+members = [".", "omeinsum-cli"]

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,11 @@ NON_GPU_FEATURES := tropical parallel
 .PHONY: docs-build docs-serve docs-book docs-book-serve
 .PHONY: fmt fmt-check clippy lint coverage
 .PHONY: example-basic example-tropical
+.PHONY: cli
+.PHONY: release copilot-review run-plan
+
+# Cross-platform sed in-place: macOS needs -i '', Linux needs -i
+SED_I := sed -i$(shell if [ "$$(uname)" = "Darwin" ]; then echo " ''"; fi)
 
 # Default target
 all: build test
@@ -56,6 +61,18 @@ help:
 	@echo ""
 	@echo "Utility targets:"
 	@echo "  clean          - Clean build artifacts"
+	@echo ""
+	@echo "CLI targets:"
+	@echo "  cli            - Build and install the omeinsum CLI to ~/.cargo/bin"
+	@echo ""
+	@echo "Release targets:"
+	@echo "  release V=x.y.z - Tag and push a new release (triggers CI publish)"
+	@echo "  copilot-review   - Request Copilot code review on current PR"
+	@echo ""
+	@echo "Agent targets:"
+	@echo "  run-plan         - Execute a plan with Claude or Codex (latest plan in docs/plans/)"
+	@echo "                     Set RUNNER=claude to use Claude (default: codex)"
+	@echo "                     Override CLAUDE_MODEL or CODEX_MODEL to pick a different model"
 
 #==============================================================================
 # Environment Setup
@@ -185,3 +202,72 @@ clean:
 	rm -rf coverage/
 	rm -rf docs/book/
 	@echo "Clean complete."
+
+#==============================================================================
+# CLI
+#==============================================================================
+
+cli:
+	cargo install --path omeinsum-cli
+
+#==============================================================================
+# Release
+#==============================================================================
+
+# Release a new version: make release V=0.2.0
+release:
+ifndef V
+	$(error Usage: make release V=x.y.z)
+endif
+	@echo "Releasing v$(V)..."
+	$(SED_I) 's/^version = ".*"/version = "$(V)"/' Cargo.toml
+	cargo check
+	git add Cargo.toml
+	git commit -m "release: v$(V)"
+	git tag -a "v$(V)" -m "Release v$(V)"
+	git push origin main --tags
+	@echo "v$(V) pushed — CI will publish to crates.io"
+
+# Request Copilot code review on the current PR
+# Requires: gh extension install ChrisCarini/gh-copilot-review
+copilot-review:
+	@PR=$$(gh pr view --json number --jq .number 2>/dev/null) || { echo "No PR found for current branch"; exit 1; }; \
+	echo "Requesting Copilot review on PR #$$PR..."; \
+	gh copilot-review $$PR
+
+#==============================================================================
+# Agent-driven plan execution
+#==============================================================================
+
+RUNNER ?= codex
+CLAUDE_MODEL ?= opus
+CODEX_MODEL ?= gpt-5.4
+
+# Run a plan with Codex or Claude
+# Usage: make run-plan [INSTRUCTIONS="..."] [OUTPUT=output.log] [RUNNER=codex]
+# PLAN_FILE defaults to the most recently modified file in docs/plans/
+INSTRUCTIONS ?=
+OUTPUT ?= run-plan-output.log
+PLAN_FILE ?= $(shell ls -t docs/plans/*.md 2>/dev/null | head -1)
+
+run-plan:
+	@. scripts/make_helpers.sh; \
+	NL=$$'\n'; \
+	BRANCH=$$(git branch --show-current); \
+	PLAN_FILE="$(PLAN_FILE)"; \
+	if [ -z "$$PLAN_FILE" ]; then echo "No plan files found in docs/plans/"; exit 1; fi; \
+	if [ "$(RUNNER)" = "claude" ]; then \
+		PROCESS="1. Read the plan file$${NL}2. Execute the plan — it specifies which skill(s) to use$${NL}3. Push: git push origin $$BRANCH$${NL}4. If a PR already exists for this branch, skip. Otherwise create one."; \
+	else \
+		PROCESS="1. Read the plan file$${NL}2. If the plan references repo-local workflow docs under .claude/skills/*/SKILL.md, open and follow them directly. Treat slash-command names as aliases for those files.$${NL}3. Execute the tasks step by step. For each task, implement and test before moving on.$${NL}4. Push: git push origin $$BRANCH$${NL}5. If a PR already exists for this branch, skip. Otherwise create one."; \
+	fi; \
+	PROMPT="Execute the plan in '$$PLAN_FILE'."; \
+	if [ "$(RUNNER)" != "claude" ]; then \
+		PROMPT="$${PROMPT}$${NL}$${NL}Repo-local skills live in .claude/skills/*/SKILL.md. Treat any slash-command references in the plan as aliases for those skill files."; \
+	fi; \
+	if [ -n "$(INSTRUCTIONS)" ]; then \
+		PROMPT="$${PROMPT}$${NL}$${NL}## Additional Instructions$${NL}$(INSTRUCTIONS)"; \
+	fi; \
+	PROMPT="$${PROMPT}$${NL}$${NL}## Process$${NL}$${PROCESS}$${NL}$${NL}## Rules$${NL}- Tests should be strong enough to catch regressions.$${NL}- Do not modify tests to make them pass.$${NL}- Test failure must be reported."; \
+	echo "=== Prompt ===" && echo "$$PROMPT" && echo "===" ; \
+	RUNNER="$(RUNNER)" run_agent "$(OUTPUT)" "$$PROMPT"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ cargo test --features tropical
 | `MinPlus<T>` | min | + | Shortest path |
 | `MaxMul<T>` | max | × | Max probability |
 
+## CLI Tool
+
+Install and use the `omeinsum` CLI for contraction optimization and execution without writing Rust code:
+
+```bash
+make cli                    # install to ~/.cargo/bin
+
+omeinsum optimize "ij,jk->ik" --sizes "i=2,j=3,k=2" -o topo.json
+omeinsum contract tensors.json -t topo.json
+```
+
+See the [CLI documentation](https://tensor4all.github.io/omeinsum-rs/cli.html) for JSON formats, parenthesized expressions, and a full walkthrough.
+
 ## Contraction Optimization
 
 ```rust

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@
 - [Tensor API](./tensor-api.md)
 - [Einsum API](./einsum-api.md)
 - [Contraction Optimization](./optimization.md)
+- [CLI Tool](./cli.md)
 - [Showcase Examples](./examples.md)
 
 # Reference

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -1,0 +1,176 @@
+# CLI Tool
+
+The `omeinsum` command-line tool optimizes contraction order and executes tensor contractions from JSON files, without writing Rust code.
+
+## Installation
+
+```bash
+# From the repository root
+make cli
+
+# Or directly with Cargo
+cargo install --path omeinsum-cli
+```
+
+This installs the `omeinsum` binary to `~/.cargo/bin/`.
+
+## Subcommands
+
+### `omeinsum optimize`
+
+Finds an efficient contraction order for an einsum expression.
+
+```bash
+omeinsum optimize "ij,jk,kl->il" --sizes "i=2,j=3,k=4,l=5" -o topology.json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<expression>` | yes | Einsum in NumPy notation, e.g. `"ij,jk->ik"` |
+| `--sizes` | yes | Dimension sizes as `label=size` pairs, e.g. `"i=2,j=3,k=4"` |
+| `--method` | no | `greedy` (default) or `treesa` |
+| `-o, --output` | no | Output file (default: stdout) |
+| `--pretty` | no | `true` or `false`; auto-detects TTY when omitted |
+
+The output is a topology JSON that encodes the contraction tree. Pass it to `omeinsum contract` with `-t`.
+
+#### Greedy parameters
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--alpha` | 0.0 | Weight balancing output size vs input size reduction |
+| `--temperature` | 0.0 | Stochastic selection temperature; 0 = deterministic |
+
+Example with stochastic greedy:
+
+```bash
+omeinsum optimize "ij,jk,kl->il" --sizes "i=10,j=20,k=30,l=40" \
+    --method greedy --alpha 0.5 --temperature 0.1
+```
+
+#### TreeSA parameters
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--ntrials` | 10 | Number of independent SA trials |
+| `--niters` | 50 | Iterations per temperature level |
+| `--betas` | `0.01:0.05:15.0` | Inverse temperature schedule as `start:step:stop` |
+| `--sc-target` | 20.0 | Space complexity target threshold |
+| `--tc-weight` | 1.0 | Time complexity weight in score function |
+| `--sc-weight` | 1.0 | Space complexity weight in score function |
+| `--rw-weight` | 0.0 | Read-write complexity weight |
+
+The score function is: `score = tc_weight * 2^tc + rw_weight * 2^rw + sc_weight * max(0, 2^sc - 2^sc_target)`.
+
+Example with custom TreeSA:
+
+```bash
+omeinsum optimize "ij,jk,kl,lm->im" --sizes "i=10,j=20,k=30,l=40,m=50" \
+    --method treesa --ntrials 20 --niters 100 --sc-target 25.0
+```
+
+### `omeinsum contract`
+
+Executes a tensor contraction. Requires either a pre-computed topology (`-t`) or an explicit contraction order (`--expr`).
+
+```bash
+# Using a topology from optimize
+omeinsum contract tensors.json -t topology.json -o result.json
+
+# Using a parenthesized expression
+omeinsum contract tensors.json --expr "(ij,jk),kl->il"
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<tensors>` | yes | Path to tensors JSON file |
+| `-t, --topology` | one of `-t` or `--expr` | Topology JSON from `optimize` |
+| `--expr` | one of `-t` or `--expr` | Parenthesized expression (see below) |
+| `-o, --output` | no | Output file (default: stdout) |
+| `--pretty` | no | `true` or `false`; auto-detects TTY when omitted |
+
+## Parenthesized Expressions
+
+The `--expr` flag specifies the contraction order using parentheses. Each pair of parentheses denotes one binary contraction step, executed inside-out:
+
+```
+(ij,jk),kl->il      # contract ij,jk first, then result with kl
+ij,(jk,kl)->il       # contract jk,kl first, then ij with result
+((ab,bc),cd),de->ae  # left-to-right chain: ab*bc, then *cd, then *de
+```
+
+Tensors are numbered left-to-right in the flat expression. The parenthesization controls which tensors are contracted first, which can significantly affect performance for large networks.
+
+If you don't know the best order, use `omeinsum optimize` to find one automatically.
+
+## JSON Formats
+
+### Input: Tensors File
+
+```json
+{
+  "dtype": "f64",
+  "order": "row_major",
+  "tensors": [
+    { "shape": [2, 3], "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0] },
+    { "shape": [3, 2], "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0] }
+  ]
+}
+```
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `dtype` | `f32`, `f64`, `c32`, `c64` | Scalar type. Complex types interleave real/imaginary: `[re, im, re, im, ...]` |
+| `order` | `row_major`, `col_major` | Memory layout of `data` arrays. Default: `col_major` |
+| `tensors` | array | Each entry has a `shape` and flat `data` array |
+
+> **Note for Python/NumPy users:** NumPy uses row-major (C order) by default.
+> If you export data with `tensor.flatten().tolist()`, set `"order": "row_major"`.
+> Omitting the `order` field defaults to `col_major` (Fortran/Julia convention),
+> which will silently produce wrong results if your data is row-major.
+
+### Output: Result File
+
+```json
+{
+  "dtype": "f64",
+  "order": "row_major",
+  "shape": [2, 2],
+  "data": [7.0, 10.0, 15.0, 22.0]
+}
+```
+
+The output uses the same `order` as the input. The `data` array is the flattened result tensor.
+
+### Intermediate: Topology File
+
+Produced by `optimize`, consumed by `contract -t`. You can treat it as a black box. The structure contains the original expression, a label-to-integer mapping, dimension sizes, and a binary contraction tree.
+
+## Example: Full Pipeline
+
+```bash
+# 1. Create input tensors (2x3 matrix times 3x2 matrix, row-major)
+cat > /tmp/tensors.json << 'EOF'
+{
+  "dtype": "f64",
+  "order": "row_major",
+  "tensors": [
+    { "shape": [2, 3], "data": [1, 2, 3, 4, 5, 6] },
+    { "shape": [3, 2], "data": [1, 2, 3, 4, 5, 6] }
+  ]
+}
+EOF
+
+# 2. Optimize contraction order
+omeinsum optimize "ij,jk->ik" --sizes "i=2,j=3,k=2" -o /tmp/topology.json
+
+# 3. Contract using topology
+omeinsum contract /tmp/tensors.json -t /tmp/topology.json
+
+# Output: {"dtype":"f64","order":"row_major","shape":[2,2],"data":[22.0,28.0,49.0,64.0]}
+
+# Or contract directly with --expr (no optimize step needed)
+omeinsum contract /tmp/tensors.json --expr "(ij,jk)->ik"
+
+# Same output
+```

--- a/omeinsum-cli/Cargo.toml
+++ b/omeinsum-cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "omeinsum-cli"
+version = "0.1.0"
+edition = "2021"
+description = "CLI for Einstein summation optimization and contraction"
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "omeinsum"
+path = "src/main.rs"
+
+[dependencies]
+omeinsum = { path = ".." }
+omeco = "0.2"
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+num-complex = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+serde_json = "1"
+tempfile = "3"

--- a/omeinsum-cli/Cargo.toml
+++ b/omeinsum-cli/Cargo.toml
@@ -19,5 +19,6 @@ num-complex = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "2"
+predicates = "3"
 serde_json = "1"
 tempfile = "3"

--- a/omeinsum-cli/src/contract.rs
+++ b/omeinsum-cli/src/contract.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::io::{self, IsTerminal, Write};
 
 use num_complex::{Complex32, Complex64};
+use omeco::NestedEinsum;
 use omeinsum::algebra::Standard;
 use omeinsum::{Algebra, BackendScalar, Cpu, Einsum, Tensor};
 
@@ -193,6 +194,7 @@ where
                 .map_err(|_| format!("Invalid size_dict key '{key}'"))
         })
         .collect::<Result<_, _>>()?;
+    validate_topology_tree(&topology.tree, tensors.len(), &size_dict)?;
 
     let parsed = parse_flat(&topology.expression)?;
     if tensors.len() != parsed.ixs.len() {
@@ -262,6 +264,43 @@ fn validate_shape(data: &[f64], shape: &[usize], is_complex: bool) -> Result<(),
         ));
     }
     Ok(())
+}
+
+fn validate_topology_tree(
+    tree: &NestedEinsum<usize>,
+    num_tensors: usize,
+    size_dict: &HashMap<usize, usize>,
+) -> Result<(), String> {
+    match tree {
+        NestedEinsum::Leaf { tensor_index } => {
+            if *tensor_index >= num_tensors {
+                return Err(format!(
+                    "Topology leaf tensor_index {} out of range for {} tensors",
+                    tensor_index, num_tensors
+                ));
+            }
+            Ok(())
+        }
+        NestedEinsum::Node { args, eins } => {
+            if args.len() != 2 {
+                return Err(format!(
+                    "Topology tree must be binary, found node with {} children",
+                    args.len()
+                ));
+            }
+
+            for label in eins.ixs.iter().flatten().chain(eins.iy.iter()) {
+                if !size_dict.contains_key(label) {
+                    return Err(format!("Topology references unknown label index {}", label));
+                }
+            }
+
+            for arg in args {
+                validate_topology_tree(arg, num_tensors, size_dict)?;
+            }
+            Ok(())
+        }
+    }
 }
 
 fn interleaved_to_complex<T>(data: &[f64], make_complex: fn(f64, f64) -> T) -> Vec<T> {

--- a/omeinsum-cli/src/contract.rs
+++ b/omeinsum-cli/src/contract.rs
@@ -1,10 +1,372 @@
+use std::collections::HashMap;
+use std::io::{self, IsTerminal, Write};
+
+use num_complex::{Complex32, Complex64};
+use omeinsum::algebra::Standard;
+use omeinsum::{Algebra, BackendScalar, Cpu, Einsum, Tensor};
+
+use crate::format::{
+    col_to_row_major, row_to_col_major, Dtype, ResultFile, StorageOrder, TensorsFile,
+    TopologyFile,
+};
+use crate::parse::{parse_flat, parse_parenthesized};
+
 /// Run the contract subcommand.
 pub fn run(
-    _tensors_path: &str,
-    _topology_path: Option<&str>,
-    _expr: Option<&str>,
-    _output: Option<&str>,
-    _pretty: Option<bool>,
+    tensors_path: &str,
+    topology_path: Option<&str>,
+    expr: Option<&str>,
+    output: Option<&str>,
+    pretty: Option<bool>,
 ) -> Result<(), String> {
-    Err("contract: not yet implemented".to_string())
+    match (topology_path, expr) {
+        (Some(_), Some(_)) => return Err("Cannot specify both -t and --expr".to_string()),
+        (None, None) => return Err("Must specify either -t or --expr".to_string()),
+        _ => {}
+    }
+
+    let tensors_json = std::fs::read_to_string(tensors_path)
+        .map_err(|err| format!("Failed to read '{tensors_path}': {err}"))?;
+    let tensors_file: TensorsFile = serde_json::from_str(&tensors_json)
+        .map_err(|err| format!("Failed to parse tensors JSON: {err}"))?;
+
+    match tensors_file.dtype {
+        Dtype::F32 => run_real(
+            &tensors_file,
+            topology_path,
+            expr,
+            output,
+            pretty,
+            |value| value as f32,
+            |value| value as f64,
+        ),
+        Dtype::F64 => run_real(
+            &tensors_file,
+            topology_path,
+            expr,
+            output,
+            pretty,
+            |value| value,
+            |value| value,
+        ),
+        Dtype::C32 => run_complex(
+            &tensors_file,
+            topology_path,
+            expr,
+            output,
+            pretty,
+            |re, im| Complex32::new(re as f32, im as f32),
+            |value| (value.re as f64, value.im as f64),
+        ),
+        Dtype::C64 => run_complex(
+            &tensors_file,
+            topology_path,
+            expr,
+            output,
+            pretty,
+            Complex64::new,
+            |value| (value.re, value.im),
+        ),
+    }
+}
+
+fn run_real<T>(
+    tensors_file: &TensorsFile,
+    topology_path: Option<&str>,
+    expr: Option<&str>,
+    output: Option<&str>,
+    pretty: Option<bool>,
+    from_f64: fn(f64) -> T,
+    to_f64: fn(T) -> f64,
+) -> Result<(), String>
+where
+    T: omeinsum::algebra::Scalar + BackendScalar<Cpu>,
+    Standard<T>: Algebra<Scalar = T, Index = u32>,
+{
+    let tensors: Vec<Tensor<T, Cpu>> = tensors_file
+        .tensors
+        .iter()
+        .map(|entry| {
+            validate_shape(&entry.data, &entry.shape, false)?;
+            let col_major_data = match tensors_file.order {
+                StorageOrder::RowMajor => row_to_col_major(&entry.data, &entry.shape),
+                StorageOrder::ColMajor => entry.data.clone(),
+            };
+            let data: Vec<T> = col_major_data.into_iter().map(from_f64).collect();
+            Ok(Tensor::<T, Cpu>::from_data(&data, &entry.shape))
+        })
+        .collect::<Result<_, String>>()?;
+
+    let tensor_refs: Vec<&Tensor<T, Cpu>> = tensors.iter().collect();
+    let result = match topology_path {
+        Some(path) => execute_with_topology(&tensor_refs, path)?,
+        None => execute_with_expr(&tensor_refs, expr.unwrap())?,
+    };
+
+    let mut data: Vec<f64> = result.to_vec().into_iter().map(to_f64).collect();
+    if tensors_file.order == StorageOrder::RowMajor {
+        data = col_to_row_major(&data, result.shape());
+    }
+
+    let result_file = ResultFile {
+        dtype: tensors_file.dtype,
+        order: tensors_file.order,
+        shape: result.shape().to_vec(),
+        data,
+    };
+    write_output(&result_file, output, pretty)
+}
+
+fn run_complex<T>(
+    tensors_file: &TensorsFile,
+    topology_path: Option<&str>,
+    expr: Option<&str>,
+    output: Option<&str>,
+    pretty: Option<bool>,
+    make_complex: fn(f64, f64) -> T,
+    split_complex: fn(T) -> (f64, f64),
+) -> Result<(), String>
+where
+    T: omeinsum::algebra::Scalar + BackendScalar<Cpu>,
+    Standard<T>: Algebra<Scalar = T, Index = u32>,
+{
+    let tensors: Vec<Tensor<T, Cpu>> = tensors_file
+        .tensors
+        .iter()
+        .map(|entry| {
+            validate_shape(&entry.data, &entry.shape, true)?;
+            let col_major_data = match tensors_file.order {
+                StorageOrder::RowMajor => row_to_col_major_interleaved(&entry.data, &entry.shape),
+                StorageOrder::ColMajor => entry.data.clone(),
+            };
+            let data = interleaved_to_complex(&col_major_data, make_complex);
+            Ok(Tensor::<T, Cpu>::from_data(&data, &entry.shape))
+        })
+        .collect::<Result<_, String>>()?;
+
+    let tensor_refs: Vec<&Tensor<T, Cpu>> = tensors.iter().collect();
+    let result = match topology_path {
+        Some(path) => execute_with_topology(&tensor_refs, path)?,
+        None => execute_with_expr(&tensor_refs, expr.unwrap())?,
+    };
+
+    let mut data = complex_to_interleaved(&result.to_vec(), split_complex);
+    if tensors_file.order == StorageOrder::RowMajor {
+        data = col_to_row_major_interleaved(&data, result.shape());
+    }
+
+    let result_file = ResultFile {
+        dtype: tensors_file.dtype,
+        order: tensors_file.order,
+        shape: result.shape().to_vec(),
+        data,
+    };
+    write_output(&result_file, output, pretty)
+}
+
+fn execute_with_topology<T>(
+    tensors: &[&Tensor<T, Cpu>],
+    topology_path: &str,
+) -> Result<Tensor<T, Cpu>, String>
+where
+    T: omeinsum::algebra::Scalar + BackendScalar<Cpu>,
+    Standard<T>: Algebra<Scalar = T, Index = u32>,
+{
+    let topology_json = std::fs::read_to_string(topology_path)
+        .map_err(|err| format!("Failed to read '{topology_path}': {err}"))?;
+    let topology: TopologyFile = serde_json::from_str(&topology_json)
+        .map_err(|err| format!("Failed to parse topology JSON: {err}"))?;
+
+    if topology.schema_version != 1 {
+        return Err(format!(
+            "Unsupported schema_version {}, expected 1",
+            topology.schema_version
+        ));
+    }
+
+    let size_dict: HashMap<usize, usize> = topology
+        .size_dict
+        .iter()
+        .map(|(key, value)| {
+            key.parse::<usize>()
+                .map(|idx| (idx, *value))
+                .map_err(|_| format!("Invalid size_dict key '{key}'"))
+        })
+        .collect::<Result<_, _>>()?;
+
+    let parsed = parse_flat(&topology.expression)?;
+    if tensors.len() != parsed.ixs.len() {
+        return Err(format!(
+            "Expression expects {} tensors but received {}",
+            parsed.ixs.len(),
+            tensors.len()
+        ));
+    }
+
+    let mut ein = Einsum::new(parsed.ixs, parsed.iy, size_dict);
+    ein.set_contraction_tree(topology.tree);
+    Ok(ein.execute::<Standard<T>, T, Cpu>(tensors))
+}
+
+fn execute_with_expr<T>(tensors: &[&Tensor<T, Cpu>], expr: &str) -> Result<Tensor<T, Cpu>, String>
+where
+    T: omeinsum::algebra::Scalar + BackendScalar<Cpu>,
+    Standard<T>: Algebra<Scalar = T, Index = u32>,
+{
+    let parsed = parse_parenthesized(expr)?;
+    if tensors.len() != parsed.ixs.len() {
+        return Err(format!(
+            "Expression expects {} tensors but received {}",
+            parsed.ixs.len(),
+            tensors.len()
+        ));
+    }
+
+    let mut size_dict = HashMap::new();
+    for (tensor, labels) in tensors.iter().zip(parsed.ixs.iter()) {
+        if tensor.ndim() != labels.len() {
+            return Err(format!(
+                "Tensor has {} dims but expression specifies {} labels",
+                tensor.ndim(),
+                labels.len()
+            ));
+        }
+
+        for (dim, label) in labels.iter().copied().enumerate() {
+            let size = tensor.shape()[dim];
+            if let Some(existing) = size_dict.insert(label, size) {
+                if existing != size {
+                    return Err(format!(
+                        "Inconsistent size for label index {}: {} vs {}",
+                        label, existing, size
+                    ));
+                }
+            }
+        }
+    }
+
+    let mut ein = Einsum::new(parsed.ixs, parsed.iy, size_dict);
+    ein.set_contraction_tree(parsed.tree);
+    Ok(ein.execute::<Standard<T>, T, Cpu>(tensors))
+}
+
+fn validate_shape(data: &[f64], shape: &[usize], is_complex: bool) -> Result<(), String> {
+    let numel: usize = shape.iter().product();
+    let expected_len = if is_complex { numel * 2 } else { numel };
+    if data.len() != expected_len {
+        return Err(format!(
+            "Data length {} doesn't match shape {:?} (expected {})",
+            data.len(),
+            shape,
+            expected_len
+        ));
+    }
+    Ok(())
+}
+
+fn interleaved_to_complex<T>(data: &[f64], make_complex: fn(f64, f64) -> T) -> Vec<T> {
+    data.chunks_exact(2)
+        .map(|pair| make_complex(pair[0], pair[1]))
+        .collect()
+}
+
+fn complex_to_interleaved<T>(data: &[T], split_complex: fn(T) -> (f64, f64)) -> Vec<f64>
+where
+    T: Copy,
+{
+    let mut result = Vec::with_capacity(data.len() * 2);
+    for value in data.iter().copied() {
+        let (re, im) = split_complex(value);
+        result.push(re);
+        result.push(im);
+    }
+    result
+}
+
+fn row_to_col_major_interleaved(data: &[f64], shape: &[usize]) -> Vec<f64> {
+    if shape.len() <= 1 {
+        return data.to_vec();
+    }
+
+    let indices = compute_row_to_col_indices(shape);
+    let mut result = vec![0.0; data.len()];
+    for (row_idx, col_idx) in indices.into_iter().enumerate() {
+        result[col_idx * 2] = data[row_idx * 2];
+        result[col_idx * 2 + 1] = data[row_idx * 2 + 1];
+    }
+    result
+}
+
+fn col_to_row_major_interleaved(data: &[f64], shape: &[usize]) -> Vec<f64> {
+    if shape.len() <= 1 {
+        return data.to_vec();
+    }
+
+    let indices = compute_row_to_col_indices(shape);
+    let mut result = vec![0.0; data.len()];
+    for (row_idx, col_idx) in indices.into_iter().enumerate() {
+        result[row_idx * 2] = data[col_idx * 2];
+        result[row_idx * 2 + 1] = data[col_idx * 2 + 1];
+    }
+    result
+}
+
+fn compute_row_to_col_indices(shape: &[usize]) -> Vec<usize> {
+    let numel: usize = shape.iter().product();
+    let col_strides = col_major_strides(shape);
+
+    (0..numel)
+        .map(|row_idx| {
+            let coords = row_major_coords(row_idx, shape);
+            coords
+                .into_iter()
+                .enumerate()
+                .map(|(dim, coord)| coord * col_strides[dim])
+                .sum()
+        })
+        .collect()
+}
+
+fn row_major_coords(mut linear_idx: usize, shape: &[usize]) -> Vec<usize> {
+    let mut coords = vec![0usize; shape.len()];
+    for dim in (0..shape.len()).rev() {
+        coords[dim] = linear_idx % shape[dim];
+        linear_idx /= shape[dim];
+    }
+    coords
+}
+
+fn col_major_strides(shape: &[usize]) -> Vec<usize> {
+    let mut strides = vec![1usize; shape.len()];
+    for dim in 1..shape.len() {
+        strides[dim] = strides[dim - 1] * shape[dim - 1];
+    }
+    strides
+}
+
+fn write_output(
+    result: &ResultFile,
+    output: Option<&str>,
+    pretty: Option<bool>,
+) -> Result<(), String> {
+    let use_pretty = pretty.unwrap_or_else(|| io::stdout().is_terminal());
+    let json = if use_pretty {
+        serde_json::to_string_pretty(result)
+    } else {
+        serde_json::to_string(result)
+    }
+    .map_err(|err| format!("JSON serialization failed: {err}"))?;
+
+    match output {
+        Some(path) => std::fs::write(path, &json)
+            .map_err(|err| format!("Failed to write '{path}': {err}"))?,
+        None => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            writeln!(handle, "{json}")
+                .map_err(|err| format!("Failed to write stdout: {err}"))?;
+        }
+    }
+
+    Ok(())
 }

--- a/omeinsum-cli/src/contract.rs
+++ b/omeinsum-cli/src/contract.rs
@@ -1,0 +1,10 @@
+/// Run the contract subcommand.
+pub fn run(
+    _tensors_path: &str,
+    _topology_path: Option<&str>,
+    _expr: Option<&str>,
+    _output: Option<&str>,
+    _pretty: Option<bool>,
+) -> Result<(), String> {
+    Err("contract: not yet implemented".to_string())
+}

--- a/omeinsum-cli/src/contract.rs
+++ b/omeinsum-cli/src/contract.rs
@@ -7,8 +7,7 @@ use omeinsum::algebra::Standard;
 use omeinsum::{Algebra, BackendScalar, Cpu, Einsum, Tensor};
 
 use crate::format::{
-    col_to_row_major, row_to_col_major, Dtype, ResultFile, StorageOrder, TensorsFile,
-    TopologyFile,
+    col_to_row_major, row_to_col_major, Dtype, ResultFile, StorageOrder, TensorsFile, TopologyFile,
 };
 use crate::parse::{parse_flat, parse_parenthesized};
 
@@ -397,13 +396,13 @@ fn write_output(
     .map_err(|err| format!("JSON serialization failed: {err}"))?;
 
     match output {
-        Some(path) => std::fs::write(path, &json)
-            .map_err(|err| format!("Failed to write '{path}': {err}"))?,
+        Some(path) => {
+            std::fs::write(path, &json).map_err(|err| format!("Failed to write '{path}': {err}"))?
+        }
         None => {
             let stdout = io::stdout();
             let mut handle = stdout.lock();
-            writeln!(handle, "{json}")
-                .map_err(|err| format!("Failed to write stdout: {err}"))?;
+            writeln!(handle, "{json}").map_err(|err| format!("Failed to write stdout: {err}"))?;
         }
     }
 

--- a/omeinsum-cli/src/format.rs
+++ b/omeinsum-cli/src/format.rs
@@ -4,17 +4,12 @@ use omeco::NestedEinsum;
 use serde::{Deserialize, Serialize};
 
 /// Storage order for tensor data in JSON.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StorageOrder {
+    #[default]
     ColMajor,
     RowMajor,
-}
-
-impl Default for StorageOrder {
-    fn default() -> Self {
-        Self::ColMajor
-    }
 }
 
 /// Scalar data type identifier.

--- a/omeinsum-cli/src/format.rs
+++ b/omeinsum-cli/src/format.rs
@@ -1,0 +1,225 @@
+use std::collections::HashMap;
+
+use omeco::NestedEinsum;
+use serde::{Deserialize, Serialize};
+
+/// Storage order for tensor data in JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StorageOrder {
+    ColMajor,
+    RowMajor,
+}
+
+impl Default for StorageOrder {
+    fn default() -> Self {
+        Self::ColMajor
+    }
+}
+
+/// Scalar data type identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub enum Dtype {
+    #[serde(rename = "f32")]
+    F32,
+    #[serde(rename = "f64")]
+    F64,
+    #[serde(rename = "c32")]
+    C32,
+    #[serde(rename = "c64")]
+    C64,
+}
+
+/// A single tensor entry in the tensors JSON file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TensorEntry {
+    pub shape: Vec<usize>,
+    pub data: Vec<f64>,
+}
+
+/// The tensors JSON file schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TensorsFile {
+    pub dtype: Dtype,
+    #[serde(default)]
+    pub order: StorageOrder,
+    pub tensors: Vec<TensorEntry>,
+}
+
+/// The topology JSON file schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologyFile {
+    pub schema_version: u32,
+    pub expression: String,
+    pub label_map: HashMap<String, usize>,
+    pub size_dict: HashMap<String, usize>,
+    pub method: String,
+    pub tree: NestedEinsum<usize>,
+}
+
+/// The result JSON file schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResultFile {
+    pub dtype: Dtype,
+    pub order: StorageOrder,
+    pub shape: Vec<usize>,
+    pub data: Vec<f64>,
+}
+
+/// Convert row-major flat data to column-major for a given shape.
+pub fn row_to_col_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
+    if shape.len() <= 1 {
+        return data.to_vec();
+    }
+
+    let numel: usize = shape.iter().product();
+    let mut result = vec![0.0; numel];
+    let col_strides = col_major_strides(shape);
+
+    for (row_idx, value) in data.iter().copied().enumerate() {
+        let coords = row_major_coords(row_idx, shape);
+        let mut col_idx = 0usize;
+        for (dim, coord) in coords.into_iter().enumerate() {
+            col_idx += coord * col_strides[dim];
+        }
+        result[col_idx] = value;
+    }
+
+    result
+}
+
+/// Convert column-major flat data to row-major for a given shape.
+pub fn col_to_row_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
+    if shape.len() <= 1 {
+        return data.to_vec();
+    }
+
+    let numel: usize = shape.iter().product();
+    let mut result = vec![0.0; numel];
+    let row_strides = row_major_strides(shape);
+
+    for (col_idx, value) in data.iter().copied().enumerate() {
+        let coords = col_major_coords(col_idx, shape);
+        let mut row_idx = 0usize;
+        for (dim, coord) in coords.into_iter().enumerate() {
+            row_idx += coord * row_strides[dim];
+        }
+        result[row_idx] = value;
+    }
+
+    result
+}
+
+fn row_major_strides(shape: &[usize]) -> Vec<usize> {
+    let mut strides = vec![1usize; shape.len()];
+    for i in (0..shape.len().saturating_sub(1)).rev() {
+        strides[i] = strides[i + 1] * shape[i + 1];
+    }
+    strides
+}
+
+fn col_major_strides(shape: &[usize]) -> Vec<usize> {
+    let mut strides = vec![1usize; shape.len()];
+    for i in 1..shape.len() {
+        strides[i] = strides[i - 1] * shape[i - 1];
+    }
+    strides
+}
+
+fn row_major_coords(mut linear_idx: usize, shape: &[usize]) -> Vec<usize> {
+    let mut coords = vec![0usize; shape.len()];
+    for dim in (0..shape.len()).rev() {
+        coords[dim] = linear_idx % shape[dim];
+        linear_idx /= shape[dim];
+    }
+    coords
+}
+
+fn col_major_coords(mut linear_idx: usize, shape: &[usize]) -> Vec<usize> {
+    let mut coords = vec![0usize; shape.len()];
+    for dim in 0..shape.len() {
+        coords[dim] = linear_idx % shape[dim];
+        linear_idx /= shape[dim];
+    }
+    coords
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tensors_file_roundtrip() {
+        let tf = TensorsFile {
+            dtype: Dtype::F64,
+            order: StorageOrder::ColMajor,
+            tensors: vec![TensorEntry {
+                shape: vec![2, 3],
+                data: vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            }],
+        };
+        let json = serde_json::to_string(&tf).unwrap();
+        let parsed: TensorsFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.dtype, Dtype::F64);
+        assert_eq!(parsed.order, StorageOrder::ColMajor);
+        assert_eq!(parsed.tensors[0].shape, vec![2, 3]);
+    }
+
+    #[test]
+    fn test_tensors_file_default_order() {
+        let json = r#"{"dtype":"f64","tensors":[{"shape":[2],"data":[1.0,2.0]}]}"#;
+        let parsed: TensorsFile = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.order, StorageOrder::ColMajor);
+    }
+
+    #[test]
+    fn test_result_file_roundtrip() {
+        let rf = ResultFile {
+            dtype: Dtype::F32,
+            order: StorageOrder::RowMajor,
+            shape: vec![2, 2],
+            data: vec![1.0, 2.0, 3.0, 4.0],
+        };
+        let json = serde_json::to_string(&rf).unwrap();
+        let parsed: ResultFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.dtype, Dtype::F32);
+        assert_eq!(parsed.order, StorageOrder::RowMajor);
+    }
+
+    #[test]
+    fn test_row_to_col_major_2x3() {
+        let row_data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let col_data = row_to_col_major(&row_data, &[2, 3]);
+        assert_eq!(col_data, vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0]);
+    }
+
+    #[test]
+    fn test_col_to_row_major_2x3() {
+        let col_data = vec![1.0, 4.0, 2.0, 5.0, 3.0, 6.0];
+        let row_data = col_to_row_major(&col_data, &[2, 3]);
+        assert_eq!(row_data, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[test]
+    fn test_row_col_roundtrip() {
+        let original = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
+        let shape = [2, 2, 2];
+        let col = row_to_col_major(&original, &shape);
+        let back = col_to_row_major(&col, &shape);
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn test_scalar_no_conversion() {
+        let data = vec![42.0];
+        assert_eq!(row_to_col_major(&data, &[]), data);
+        assert_eq!(col_to_row_major(&data, &[]), data);
+    }
+
+    #[test]
+    fn test_1d_no_conversion() {
+        let data = vec![1.0, 2.0, 3.0];
+        assert_eq!(row_to_col_major(&data, &[3]), data);
+        assert_eq!(col_to_row_major(&data, &[3]), data);
+    }
+}

--- a/omeinsum-cli/src/main.rs
+++ b/omeinsum-cli/src/main.rs
@@ -1,0 +1,30 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "omeinsum", about = "Einstein summation CLI")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Optimize contraction order for an einsum expression
+    Optimize,
+    /// Execute a tensor contraction
+    Contract,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Optimize => {
+            eprintln!("optimize: not yet implemented");
+            std::process::exit(1);
+        }
+        Commands::Contract => {
+            eprintln!("contract: not yet implemented");
+            std::process::exit(1);
+        }
+    }
+}

--- a/omeinsum-cli/src/main.rs
+++ b/omeinsum-cli/src/main.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+mod format;
 mod parse;
 
 #[derive(Parser)]

--- a/omeinsum-cli/src/main.rs
+++ b/omeinsum-cli/src/main.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 
+mod contract;
 mod format;
+mod optimize;
 mod parse;
 
 #[derive(Parser)]
@@ -13,21 +15,76 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Optimize contraction order for an einsum expression
-    Optimize,
+    Optimize {
+        /// Einsum expression in NumPy notation (e.g., "ij,jk->ik")
+        expression: String,
+
+        /// Dimension sizes as "label=size" pairs (e.g., "i=2,j=3,k=4")
+        #[arg(long)]
+        sizes: String,
+
+        /// Optimization method
+        #[arg(long, default_value = "greedy")]
+        method: String,
+
+        /// Output file (default: stdout)
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Pretty-print JSON (default: auto-detect TTY)
+        #[arg(long)]
+        pretty: Option<bool>,
+    },
     /// Execute a tensor contraction
-    Contract,
+    Contract {
+        /// Tensors JSON file
+        tensors: String,
+
+        /// Topology JSON file
+        #[arg(short = 't', long)]
+        topology: Option<String>,
+
+        /// Parenthesized einsum expression with explicit contraction order
+        #[arg(long)]
+        expr: Option<String>,
+
+        /// Output file (default: stdout)
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Pretty-print JSON (default: auto-detect TTY)
+        #[arg(long)]
+        pretty: Option<bool>,
+    },
 }
 
 fn main() {
     let cli = Cli::parse();
-    match cli.command {
-        Commands::Optimize => {
-            eprintln!("optimize: not yet implemented");
-            std::process::exit(1);
-        }
-        Commands::Contract => {
-            eprintln!("contract: not yet implemented");
-            std::process::exit(1);
-        }
+    let result = match cli.command {
+        Commands::Optimize {
+            expression,
+            sizes,
+            method,
+            output,
+            pretty,
+        } => optimize::run(&expression, &sizes, &method, output.as_deref(), pretty),
+        Commands::Contract {
+            tensors,
+            topology,
+            expr,
+            output,
+            pretty,
+        } => contract::run(
+            &tensors,
+            topology.as_deref(),
+            expr.as_deref(),
+            output.as_deref(),
+            pretty,
+        ),
+    };
+
+    if let Err(err) = result {
+        eprintln!("Error: {err}");
+        std::process::exit(1);
     }
 }

--- a/omeinsum-cli/src/main.rs
+++ b/omeinsum-cli/src/main.rs
@@ -6,7 +6,7 @@ mod optimize;
 mod parse;
 
 #[derive(Parser)]
-#[command(name = "omeinsum", about = "Einstein summation CLI")]
+#[command(name = "omeinsum", version, about = "Einstein summation CLI")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -23,9 +23,47 @@ enum Commands {
         #[arg(long)]
         sizes: String,
 
-        /// Optimization method
+        /// Optimization method: "greedy" or "treesa"
         #[arg(long, default_value = "greedy")]
         method: String,
+
+        // -- greedy parameters --
+        /// [greedy] Weight for output-vs-input size balance (default: 0.0)
+        #[arg(long)]
+        alpha: Option<f64>,
+
+        /// [greedy] Temperature for stochastic selection; 0 = deterministic (default: 0.0)
+        #[arg(long)]
+        temperature: Option<f64>,
+
+        // -- treesa parameters --
+        /// [treesa] Number of independent SA trials (default: 10)
+        #[arg(long)]
+        ntrials: Option<usize>,
+
+        /// [treesa] Iterations per temperature level (default: 50)
+        #[arg(long)]
+        niters: Option<usize>,
+
+        /// [treesa] Space complexity target threshold (default: 20.0)
+        #[arg(long)]
+        sc_target: Option<f64>,
+
+        /// [treesa] Inverse temperature schedule as "start:step:stop" (default: "0.01:0.05:15.0")
+        #[arg(long)]
+        betas: Option<String>,
+
+        /// [treesa] Time complexity weight (default: 1.0)
+        #[arg(long)]
+        tc_weight: Option<f64>,
+
+        /// [treesa] Space complexity weight (default: 1.0)
+        #[arg(long)]
+        sc_weight: Option<f64>,
+
+        /// [treesa] Read-write complexity weight (default: 0.0)
+        #[arg(long)]
+        rw_weight: Option<f64>,
 
         /// Output file (default: stdout)
         #[arg(short, long)]
@@ -65,9 +103,35 @@ fn main() {
             expression,
             sizes,
             method,
+            alpha,
+            temperature,
+            ntrials,
+            niters,
+            sc_target,
+            betas,
+            tc_weight,
+            sc_weight,
+            rw_weight,
             output,
             pretty,
-        } => optimize::run(&expression, &sizes, &method, output.as_deref(), pretty),
+        } => optimize::run(
+            &expression,
+            &sizes,
+            &method,
+            optimize::OptimizeParams {
+                alpha,
+                temperature,
+                ntrials,
+                niters,
+                sc_target,
+                betas,
+                tc_weight,
+                sc_weight,
+                rw_weight,
+            },
+            output.as_deref(),
+            pretty,
+        ),
         Commands::Contract {
             tensors,
             topology,

--- a/omeinsum-cli/src/main.rs
+++ b/omeinsum-cli/src/main.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
 
+mod parse;
+
 #[derive(Parser)]
 #[command(name = "omeinsum", about = "Einstein summation CLI")]
 struct Cli {

--- a/omeinsum-cli/src/optimize.rs
+++ b/omeinsum-cli/src/optimize.rs
@@ -1,0 +1,142 @@
+use std::collections::HashMap;
+use std::io::{self, IsTerminal, Write};
+
+use crate::format::TopologyFile;
+use crate::parse::parse_flat;
+
+/// Run the optimize subcommand.
+pub fn run(
+    expr: &str,
+    sizes_str: &str,
+    method: &str,
+    output: Option<&str>,
+    pretty: Option<bool>,
+) -> Result<(), String> {
+    let parsed = parse_flat(expr)?;
+    let size_dict = parse_sizes(sizes_str, &parsed.label_map)?;
+
+    let mut ein = omeinsum::Einsum::new(parsed.ixs.clone(), parsed.iy.clone(), size_dict.clone());
+    match method {
+        "greedy" => {
+            ein.optimize_greedy();
+        }
+        "treesa" => {
+            ein.optimize_treesa();
+        }
+        _ => {
+            return Err(format!(
+                "Unknown method '{method}': expected 'greedy' or 'treesa'"
+            ));
+        }
+    }
+
+    let tree = ein
+        .contraction_tree()
+        .ok_or_else(|| "Optimization produced no contraction tree".to_string())?
+        .clone();
+
+    let label_map = parsed
+        .label_map
+        .iter()
+        .map(|(label, idx)| (label.to_string(), *idx))
+        .collect();
+    let size_dict = size_dict
+        .iter()
+        .map(|(idx, size)| (idx.to_string(), *size))
+        .collect();
+
+    let topology = TopologyFile {
+        schema_version: 1,
+        expression: expr.to_string(),
+        label_map,
+        size_dict,
+        method: method.to_string(),
+        tree,
+    };
+
+    let use_pretty = pretty.unwrap_or_else(|| io::stdout().is_terminal());
+    let json = if use_pretty {
+        serde_json::to_string_pretty(&topology)
+    } else {
+        serde_json::to_string(&topology)
+    }
+    .map_err(|err| format!("JSON serialization failed: {err}"))?;
+
+    match output {
+        Some(path) => std::fs::write(path, &json)
+            .map_err(|err| format!("Failed to write '{path}': {err}"))?,
+        None => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            writeln!(handle, "{json}")
+                .map_err(|err| format!("Failed to write to stdout: {err}"))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse "--sizes" string like "i=2,j=3,k=4" into a size_dict.
+fn parse_sizes(
+    sizes_str: &str,
+    label_map: &HashMap<char, usize>,
+) -> Result<HashMap<usize, usize>, String> {
+    let mut size_dict = HashMap::new();
+
+    for pair in sizes_str.split(',') {
+        let pair = pair.trim();
+        let (label_str, size_str) = pair
+            .split_once('=')
+            .ok_or_else(|| format!("Invalid size spec '{pair}': expected 'label=size'"))?;
+
+        let label_str = label_str.trim();
+        let size_str = size_str.trim();
+        if label_str.len() != 1 {
+            return Err(format!(
+                "Label must be a single character, got '{label_str}'"
+            ));
+        }
+
+        let ch = label_str.chars().next().unwrap();
+        let idx = label_map
+            .get(&ch)
+            .ok_or_else(|| format!("Label '{ch}' not found in expression"))?;
+        let size = size_str
+            .parse::<usize>()
+            .map_err(|_| format!("Invalid size '{size_str}' for label '{ch}'"))?;
+        if size == 0 {
+            return Err(format!("Size for label '{ch}' must be >= 1"));
+        }
+
+        size_dict.insert(*idx, size);
+    }
+
+    Ok(size_dict)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_sizes() {
+        let label_map: HashMap<char, usize> =
+            [('i', 0), ('j', 1), ('k', 2)].into_iter().collect();
+        let sizes = parse_sizes("i=2,j=3,k=4", &label_map).unwrap();
+        assert_eq!(sizes[&0], 2);
+        assert_eq!(sizes[&1], 3);
+        assert_eq!(sizes[&2], 4);
+    }
+
+    #[test]
+    fn test_parse_sizes_unknown_label() {
+        let label_map: HashMap<char, usize> = [('i', 0)].into_iter().collect();
+        assert!(parse_sizes("z=5", &label_map).is_err());
+    }
+
+    #[test]
+    fn test_parse_sizes_zero_error() {
+        let label_map: HashMap<char, usize> = [('i', 0)].into_iter().collect();
+        assert!(parse_sizes("i=0", &label_map).is_err());
+    }
+}

--- a/omeinsum-cli/src/optimize.rs
+++ b/omeinsum-cli/src/optimize.rs
@@ -1,39 +1,117 @@
 use std::collections::HashMap;
 use std::io::{self, IsTerminal, Write};
 
+use omeco::{optimize_code, EinCode, GreedyMethod, TreeSA};
+
 use crate::format::TopologyFile;
 use crate::parse::parse_flat;
+
+/// Method-specific hyperparameters passed from the CLI.
+#[derive(Default)]
+pub struct OptimizeParams {
+    // greedy
+    pub alpha: Option<f64>,
+    pub temperature: Option<f64>,
+    // treesa
+    pub ntrials: Option<usize>,
+    pub niters: Option<usize>,
+    pub sc_target: Option<f64>,
+    pub betas: Option<String>,
+    pub tc_weight: Option<f64>,
+    pub sc_weight: Option<f64>,
+    pub rw_weight: Option<f64>,
+}
+
+/// Parse a "start:step:stop" string into a Vec of betas.
+fn parse_betas(s: &str) -> Result<Vec<f64>, String> {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != 3 {
+        return Err(format!(
+            "Invalid betas '{s}': expected 'start:step:stop' (e.g., '0.01:0.05:15.0')"
+        ));
+    }
+    let start: f64 = parts[0]
+        .parse()
+        .map_err(|_| format!("Invalid betas start '{}'", parts[0]))?;
+    let step: f64 = parts[1]
+        .parse()
+        .map_err(|_| format!("Invalid betas step '{}'", parts[1]))?;
+    let stop: f64 = parts[2]
+        .parse()
+        .map_err(|_| format!("Invalid betas stop '{}'", parts[2]))?;
+    if step <= 0.0 {
+        return Err("Betas step must be positive".to_string());
+    }
+    let mut betas = Vec::new();
+    let mut v = start;
+    while v <= stop {
+        betas.push(v);
+        v += step;
+    }
+    if betas.is_empty() {
+        return Err(format!(
+            "Betas '{s}' produced an empty schedule (start > stop?)"
+        ));
+    }
+    Ok(betas)
+}
 
 /// Run the optimize subcommand.
 pub fn run(
     expr: &str,
     sizes_str: &str,
     method: &str,
+    params: OptimizeParams,
     output: Option<&str>,
     pretty: Option<bool>,
 ) -> Result<(), String> {
     let parsed = parse_flat(expr)?;
     let size_dict = parse_sizes(sizes_str, &parsed.label_map)?;
 
-    let mut ein = omeinsum::Einsum::new(parsed.ixs.clone(), parsed.iy.clone(), size_dict.clone());
-    match method {
+    let code = EinCode::new(parsed.ixs.clone(), parsed.iy.clone());
+    let tree = match method {
         "greedy" => {
-            ein.optimize_greedy();
+            let alpha = params.alpha.unwrap_or(0.0);
+            let temperature = params.temperature.unwrap_or(0.0);
+            let optimizer = GreedyMethod::new(alpha, temperature);
+            optimize_code(&code, &size_dict, &optimizer)
         }
         "treesa" => {
-            ein.optimize_treesa();
+            let mut optimizer = TreeSA::default();
+            if let Some(ntrials) = params.ntrials {
+                optimizer.ntrials = ntrials;
+            }
+            if let Some(niters) = params.niters {
+                optimizer.niters = niters;
+            }
+            if let Some(betas_str) = params.betas {
+                optimizer.betas = parse_betas(&betas_str)?;
+            }
+            let mut score = optimizer.score;
+            if let Some(v) = params.sc_target {
+                score.sc_target = v;
+            }
+            if let Some(v) = params.tc_weight {
+                score.tc_weight = v;
+            }
+            if let Some(v) = params.sc_weight {
+                score.sc_weight = v;
+            }
+            if let Some(v) = params.rw_weight {
+                score.rw_weight = v;
+            }
+            optimizer.score = score;
+            optimize_code(&code, &size_dict, &optimizer)
         }
         _ => {
             return Err(format!(
                 "Unknown method '{method}': expected 'greedy' or 'treesa'"
             ));
         }
-    }
+    };
 
-    let tree = ein
-        .contraction_tree()
-        .ok_or_else(|| "Optimization produced no contraction tree".to_string())?
-        .clone();
+    let tree =
+        tree.ok_or_else(|| "Optimization produced no contraction tree".to_string())?;
 
     let label_map = parsed
         .label_map

--- a/omeinsum-cli/src/optimize.rs
+++ b/omeinsum-cli/src/optimize.rs
@@ -63,8 +63,9 @@ pub fn run(
     .map_err(|err| format!("JSON serialization failed: {err}"))?;
 
     match output {
-        Some(path) => std::fs::write(path, &json)
-            .map_err(|err| format!("Failed to write '{path}': {err}"))?,
+        Some(path) => {
+            std::fs::write(path, &json).map_err(|err| format!("Failed to write '{path}': {err}"))?
+        }
         None => {
             let stdout = io::stdout();
             let mut handle = stdout.lock();
@@ -120,8 +121,7 @@ mod tests {
 
     #[test]
     fn test_parse_sizes() {
-        let label_map: HashMap<char, usize> =
-            [('i', 0), ('j', 1), ('k', 2)].into_iter().collect();
+        let label_map: HashMap<char, usize> = [('i', 0), ('j', 1), ('k', 2)].into_iter().collect();
         let sizes = parse_sizes("i=2,j=3,k=4", &label_map).unwrap();
         assert_eq!(sizes[&0], 2);
         assert_eq!(sizes[&1], 3);

--- a/omeinsum-cli/src/parse.rs
+++ b/omeinsum-cli/src/parse.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use omeco::{EinCode, NestedEinsum};
+
 /// Result of parsing a flat NumPy-style einsum expression.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParsedEinsum {
@@ -70,6 +72,240 @@ pub fn parse_flat(expr: &str) -> Result<ParsedEinsum, String> {
     Ok(ParsedEinsum { ixs, iy, label_map })
 }
 
+/// Result of parsing a parenthesized einsum expression.
+#[derive(Debug, Clone)]
+pub struct ParsedTree {
+    /// The contraction tree.
+    pub tree: NestedEinsum<usize>,
+    /// Full einsum specification for leaf tensors.
+    pub ixs: Vec<Vec<usize>>,
+    /// Output labels.
+    pub iy: Vec<usize>,
+    /// Maps single-char labels to usize indices.
+    pub label_map: HashMap<char, usize>,
+}
+
+/// Parse a parenthesized einsum expression like "(ij,jk),kl->il".
+///
+/// Parentheses encode contraction order. Each pair of parentheses
+/// produces a `Node` in the `NestedEinsum` tree. Leaf tensors are numbered
+/// left-to-right in order of appearance.
+pub fn parse_parenthesized(expr: &str) -> Result<ParsedTree, String> {
+    let (input_side, output_side) = expr
+        .split_once("->")
+        .ok_or_else(|| "Missing '->' in expression".to_string())?;
+
+    let input_side = input_side.trim();
+    let output_side = output_side.trim();
+
+    let mut label_map = HashMap::new();
+    let mut next_idx = 0usize;
+    for ch in input_side.chars().chain(output_side.chars()) {
+        if ch.is_ascii_lowercase() {
+            label_map.entry(ch).or_insert_with(|| {
+                let idx = next_idx;
+                next_idx += 1;
+                idx
+            });
+        } else if ch != '(' && ch != ')' && ch != ',' && ch != ' ' {
+            return Err(format!("Invalid character '{ch}' in expression"));
+        }
+    }
+
+    let mut iy = Vec::new();
+    for ch in output_side.chars() {
+        if !ch.is_ascii_lowercase() {
+            return Err(format!("Invalid character '{ch}' in expression"));
+        }
+        iy.push(
+            label_map
+                .get(&ch)
+                .copied()
+                .ok_or_else(|| format!("Output label '{ch}' not in inputs"))?,
+        );
+    }
+
+    let chars: Vec<char> = input_side.chars().collect();
+    let mut pos = 0usize;
+    let mut leaf_counter = 0usize;
+    let mut all_ixs = Vec::new();
+    let raw = parse_expr(&chars, &mut pos, &label_map, &mut leaf_counter, &mut all_ixs)?;
+    skip_spaces(&chars, &mut pos);
+    if pos != chars.len() {
+        return Err(format!(
+            "Unexpected character '{}' at position {}",
+            chars[pos], pos
+        ));
+    }
+
+    let input_label_set: std::collections::HashSet<usize> =
+        all_ixs.iter().flat_map(|labels| labels.iter().copied()).collect();
+    for &idx in &iy {
+        if !input_label_set.contains(&idx) {
+            let ch = label_map
+                .iter()
+                .find_map(|(&ch, &mapped)| (mapped == idx).then_some(ch))
+                .unwrap();
+            return Err(format!("Output label '{ch}' not in any input tensor"));
+        }
+    }
+
+    let (tree, _, _) = assign_subtree_iy(raw, &all_ixs, &iy)?;
+
+    Ok(ParsedTree {
+        tree,
+        ixs: all_ixs,
+        iy,
+        label_map,
+    })
+}
+
+enum RawTree {
+    Leaf(usize),
+    Node(Vec<RawTree>),
+}
+
+fn parse_expr(
+    chars: &[char],
+    pos: &mut usize,
+    label_map: &HashMap<char, usize>,
+    leaf_counter: &mut usize,
+    all_ixs: &mut Vec<Vec<usize>>,
+) -> Result<RawTree, String> {
+    let mut groups = Vec::new();
+    let mut expect_group = true;
+
+    loop {
+        skip_spaces(chars, pos);
+
+        if *pos >= chars.len() || chars[*pos] == ')' {
+            break;
+        }
+
+        if !expect_group {
+            if chars[*pos] == ',' {
+                *pos += 1;
+                expect_group = true;
+                continue;
+            }
+
+            return Err(format!(
+                "Unexpected character '{}' at position {}",
+                chars[*pos], *pos
+            ));
+        }
+
+        match chars[*pos] {
+            '(' => {
+                *pos += 1;
+                let subtree = parse_expr(chars, pos, label_map, leaf_counter, all_ixs)?;
+                skip_spaces(chars, pos);
+                if *pos >= chars.len() || chars[*pos] != ')' {
+                    return Err("Unbalanced parentheses: missing ')'".to_string());
+                }
+                *pos += 1;
+                groups.push(subtree);
+                expect_group = false;
+            }
+            ',' => return Err("Empty tensor label group".to_string()),
+            ch if ch.is_ascii_lowercase() => {
+                let mut labels = Vec::new();
+                while *pos < chars.len() && chars[*pos].is_ascii_lowercase() {
+                    let ch = chars[*pos];
+                    labels.push(
+                        label_map
+                            .get(&ch)
+                            .copied()
+                            .ok_or_else(|| format!("Unknown label '{ch}'"))?,
+                    );
+                    *pos += 1;
+                }
+
+                let tensor_idx = *leaf_counter;
+                *leaf_counter += 1;
+                all_ixs.push(labels);
+                groups.push(RawTree::Leaf(tensor_idx));
+                expect_group = false;
+            }
+            ch => {
+                return Err(format!(
+                    "Unexpected character '{}' at position {}",
+                    ch, *pos
+                ));
+            }
+        }
+    }
+
+    if groups.is_empty() || expect_group {
+        return Err("Empty expression group".to_string());
+    }
+
+    if groups.len() == 1 {
+        Ok(groups.into_iter().next().unwrap())
+    } else {
+        Ok(RawTree::Node(groups))
+    }
+}
+
+fn skip_spaces(chars: &[char], pos: &mut usize) {
+    while *pos < chars.len() && chars[*pos] == ' ' {
+        *pos += 1;
+    }
+}
+
+fn assign_subtree_iy(
+    raw: RawTree,
+    all_ixs: &[Vec<usize>],
+    global_iy: &[usize],
+) -> Result<(NestedEinsum<usize>, Vec<usize>, Vec<usize>), String> {
+    match raw {
+        RawTree::Leaf(idx) => Ok((NestedEinsum::leaf(idx), all_ixs[idx].clone(), vec![idx])),
+        RawTree::Node(children) => {
+            if children.len() != 2 {
+                return Err(format!(
+                    "Node must have exactly 2 children, got {}",
+                    children.len()
+                ));
+            }
+
+            let mut built_children = Vec::with_capacity(2);
+            let mut child_outputs = Vec::with_capacity(2);
+            let mut leaf_ids = Vec::new();
+
+            for child in children {
+                let (tree, output_labels, child_leaf_ids) =
+                    assign_subtree_iy(child, all_ixs, global_iy)?;
+                built_children.push(tree);
+                child_outputs.push(output_labels);
+                leaf_ids.extend(child_leaf_ids);
+            }
+
+            let leaf_id_set: std::collections::HashSet<usize> = leaf_ids.iter().copied().collect();
+            let external_labels: std::collections::HashSet<usize> = all_ixs
+                .iter()
+                .enumerate()
+                .filter(|(idx, _)| !leaf_id_set.contains(idx))
+                .flat_map(|(_, labels)| labels.iter().copied())
+                .collect();
+            let keep: std::collections::HashSet<usize> = global_iy
+                .iter()
+                .copied()
+                .chain(external_labels.iter().copied())
+                .collect();
+
+            let mut node_iy = Vec::new();
+            for label in child_outputs.iter().flatten().copied() {
+                if keep.contains(&label) && !node_iy.contains(&label) {
+                    node_iy.push(label);
+                }
+            }
+
+            let eins = EinCode::new(child_outputs, node_iy.clone());
+            Ok((NestedEinsum::node(built_children, eins), node_iy, leaf_ids))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,5 +368,85 @@ mod tests {
     #[test]
     fn test_parse_flat_output_not_subset_error() {
         assert!(parse_flat("ij,jk->iz").is_err());
+    }
+
+    #[test]
+    fn test_parse_paren_simple() {
+        let result = parse_parenthesized("(ij,jk),kl->il").unwrap();
+        assert_eq!(result.ixs.len(), 3);
+        assert_eq!(
+            result.iy,
+            vec![result.label_map[&'i'], result.label_map[&'l']]
+        );
+
+        match &result.tree {
+            NestedEinsum::Node { args, .. } => {
+                assert_eq!(args.len(), 2);
+                assert!(matches!(&args[0], NestedEinsum::Node { .. }));
+                assert!(matches!(
+                    &args[1],
+                    NestedEinsum::Leaf { tensor_index: 2 }
+                ));
+            }
+            _ => panic!("Expected Node at root"),
+        }
+    }
+
+    #[test]
+    fn test_parse_paren_flat_pair() {
+        let result = parse_parenthesized("ij,jk->ik").unwrap();
+        match &result.tree {
+            NestedEinsum::Node { args, .. } => {
+                assert_eq!(args.len(), 2);
+                assert!(matches!(
+                    &args[0],
+                    NestedEinsum::Leaf { tensor_index: 0 }
+                ));
+                assert!(matches!(
+                    &args[1],
+                    NestedEinsum::Leaf { tensor_index: 1 }
+                ));
+            }
+            _ => panic!("Expected Node at root"),
+        }
+    }
+
+    #[test]
+    fn test_parse_paren_subtree_iy() {
+        let result = parse_parenthesized("(ij,jk),kl->il").unwrap();
+        let i = result.label_map[&'i'];
+        let k = result.label_map[&'k'];
+
+        match &result.tree {
+            NestedEinsum::Node { args, .. } => match &args[0] {
+                NestedEinsum::Node { eins, .. } => {
+                    assert!(eins.iy.contains(&i));
+                    assert!(eins.iy.contains(&k));
+                    let j = result.label_map[&'j'];
+                    assert!(!eins.iy.contains(&j));
+                }
+                _ => panic!("Expected inner Node"),
+            },
+            _ => panic!("Expected outer Node"),
+        }
+    }
+
+    #[test]
+    fn test_parse_paren_single_tensor() {
+        let result = parse_parenthesized("ij->ji").unwrap();
+        match &result.tree {
+            NestedEinsum::Leaf { tensor_index: 0 } => {}
+            _ => panic!("Expected Leaf for single tensor"),
+        }
+    }
+
+    #[test]
+    fn test_parse_paren_unbalanced_error() {
+        assert!(parse_parenthesized("(ij,jk->ik").is_err());
+    }
+
+    #[test]
+    fn test_parse_paren_empty_group_error() {
+        assert!(parse_parenthesized("(,jk),kl->il").is_err());
     }
 }

--- a/omeinsum-cli/src/parse.rs
+++ b/omeinsum-cli/src/parse.rs
@@ -82,6 +82,7 @@ pub struct ParsedTree {
     /// Output labels.
     pub iy: Vec<usize>,
     /// Maps single-char labels to usize indices.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub label_map: HashMap<char, usize>,
 }
 

--- a/omeinsum-cli/src/parse.rs
+++ b/omeinsum-cli/src/parse.rs
@@ -1,0 +1,136 @@
+use std::collections::HashMap;
+
+/// Result of parsing a flat NumPy-style einsum expression.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedEinsum {
+    /// Index labels for each input tensor (as usize indices)
+    pub ixs: Vec<Vec<usize>>,
+    /// Output labels (as usize indices)
+    pub iy: Vec<usize>,
+    /// Maps single-char labels to usize indices
+    pub label_map: HashMap<char, usize>,
+}
+
+/// Parse a flat NumPy-style einsum expression like "ij,jk->ik".
+///
+/// Labels are single lowercase ASCII letters [a-z]. The `->` and output
+/// are required (no implicit output). Whitespace is tolerated around
+/// commas and `->`.
+pub fn parse_flat(expr: &str) -> Result<ParsedEinsum, String> {
+    let (input_side, output_side) = expr
+        .split_once("->")
+        .ok_or_else(|| "Missing '->' in expression".to_string())?;
+
+    let mut label_map = HashMap::new();
+    let mut next_idx = 0usize;
+
+    let mut get_or_insert = |ch: char| -> Result<usize, String> {
+        if !ch.is_ascii_lowercase() {
+            return Err(format!("Invalid label '{ch}': must be a-z"));
+        }
+
+        if let Some(&idx) = label_map.get(&ch) {
+            return Ok(idx);
+        }
+
+        let idx = next_idx;
+        label_map.insert(ch, idx);
+        next_idx += 1;
+        Ok(idx)
+    };
+
+    let mut ixs = Vec::new();
+    for tensor_str in input_side.split(',') {
+        let tensor_str = tensor_str.trim();
+        if tensor_str.is_empty() {
+            return Err("Empty tensor label group".to_string());
+        }
+
+        let mut labels = Vec::new();
+        for ch in tensor_str.chars() {
+            labels.push(get_or_insert(ch)?);
+        }
+        ixs.push(labels);
+    }
+
+    let input_label_set: std::collections::HashSet<usize> =
+        ixs.iter().flat_map(|labels| labels.iter().copied()).collect();
+
+    let mut iy = Vec::new();
+    for ch in output_side.trim().chars() {
+        let idx = get_or_insert(ch)?;
+        if !input_label_set.contains(&idx) {
+            return Err(format!(
+                "Output label '{ch}' not found in any input tensor"
+            ));
+        }
+        iy.push(idx);
+    }
+
+    Ok(ParsedEinsum { ixs, iy, label_map })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_flat_matmul() {
+        let result = parse_flat("ij,jk->ik").unwrap();
+        assert_eq!(result.ixs.len(), 2);
+        assert_eq!(result.ixs[0], vec![0, 1]);
+        assert_eq!(result.ixs[1], vec![1, 2]);
+        assert_eq!(result.iy, vec![0, 2]);
+        assert_eq!(result.label_map[&'i'], 0);
+        assert_eq!(result.label_map[&'j'], 1);
+        assert_eq!(result.label_map[&'k'], 2);
+    }
+
+    #[test]
+    fn test_parse_flat_three_tensors() {
+        let result = parse_flat("ij,jk,kl->il").unwrap();
+        assert_eq!(result.ixs.len(), 3);
+        assert_eq!(result.ixs[0], vec![0, 1]);
+        assert_eq!(result.ixs[1], vec![1, 2]);
+        assert_eq!(result.ixs[2], vec![2, 3]);
+        assert_eq!(result.iy, vec![0, 3]);
+    }
+
+    #[test]
+    fn test_parse_flat_trace() {
+        let result = parse_flat("ii->").unwrap();
+        assert_eq!(result.ixs, vec![vec![0, 0]]);
+        assert_eq!(result.iy, Vec::<usize>::new());
+    }
+
+    #[test]
+    fn test_parse_flat_scalar_output() {
+        let result = parse_flat("ij,ji->").unwrap();
+        assert_eq!(result.ixs[0], vec![0, 1]);
+        assert_eq!(result.ixs[1], vec![1, 0]);
+        assert_eq!(result.iy, Vec::<usize>::new());
+    }
+
+    #[test]
+    fn test_parse_flat_whitespace_tolerance() {
+        let result = parse_flat("ij , jk -> ik").unwrap();
+        assert_eq!(result.ixs[0], vec![0, 1]);
+        assert_eq!(result.ixs[1], vec![1, 2]);
+        assert_eq!(result.iy, vec![0, 2]);
+    }
+
+    #[test]
+    fn test_parse_flat_no_arrow_error() {
+        assert!(parse_flat("ij,jk").is_err());
+    }
+
+    #[test]
+    fn test_parse_flat_invalid_char_error() {
+        assert!(parse_flat("iJ,jk->ik").is_err());
+    }
+
+    #[test]
+    fn test_parse_flat_output_not_subset_error() {
+        assert!(parse_flat("ij,jk->iz").is_err());
+    }
+}

--- a/omeinsum-cli/src/parse.rs
+++ b/omeinsum-cli/src/parse.rs
@@ -55,16 +55,16 @@ pub fn parse_flat(expr: &str) -> Result<ParsedEinsum, String> {
         ixs.push(labels);
     }
 
-    let input_label_set: std::collections::HashSet<usize> =
-        ixs.iter().flat_map(|labels| labels.iter().copied()).collect();
+    let input_label_set: std::collections::HashSet<usize> = ixs
+        .iter()
+        .flat_map(|labels| labels.iter().copied())
+        .collect();
 
     let mut iy = Vec::new();
     for ch in output_side.trim().chars() {
         let idx = get_or_insert(ch)?;
         if !input_label_set.contains(&idx) {
-            return Err(format!(
-                "Output label '{ch}' not found in any input tensor"
-            ));
+            return Err(format!("Output label '{ch}' not found in any input tensor"));
         }
         iy.push(idx);
     }
@@ -130,7 +130,13 @@ pub fn parse_parenthesized(expr: &str) -> Result<ParsedTree, String> {
     let mut pos = 0usize;
     let mut leaf_counter = 0usize;
     let mut all_ixs = Vec::new();
-    let raw = parse_expr(&chars, &mut pos, &label_map, &mut leaf_counter, &mut all_ixs)?;
+    let raw = parse_expr(
+        &chars,
+        &mut pos,
+        &label_map,
+        &mut leaf_counter,
+        &mut all_ixs,
+    )?;
     skip_spaces(&chars, &mut pos);
     if pos != chars.len() {
         return Err(format!(
@@ -139,8 +145,10 @@ pub fn parse_parenthesized(expr: &str) -> Result<ParsedTree, String> {
         ));
     }
 
-    let input_label_set: std::collections::HashSet<usize> =
-        all_ixs.iter().flat_map(|labels| labels.iter().copied()).collect();
+    let input_label_set: std::collections::HashSet<usize> = all_ixs
+        .iter()
+        .flat_map(|labels| labels.iter().copied())
+        .collect();
     for &idx in &iy {
         if !input_label_set.contains(&idx) {
             let ch = label_map
@@ -165,6 +173,8 @@ enum RawTree {
     Leaf(usize),
     Node(Vec<RawTree>),
 }
+
+type BuiltTree = (NestedEinsum<usize>, Vec<usize>, Vec<usize>);
 
 fn parse_expr(
     chars: &[char],
@@ -258,7 +268,7 @@ fn assign_subtree_iy(
     raw: RawTree,
     all_ixs: &[Vec<usize>],
     global_iy: &[usize],
-) -> Result<(NestedEinsum<usize>, Vec<usize>, Vec<usize>), String> {
+) -> Result<BuiltTree, String> {
     match raw {
         RawTree::Leaf(idx) => Ok((NestedEinsum::leaf(idx), all_ixs[idx].clone(), vec![idx])),
         RawTree::Node(children) => {
@@ -384,10 +394,7 @@ mod tests {
             NestedEinsum::Node { args, .. } => {
                 assert_eq!(args.len(), 2);
                 assert!(matches!(&args[0], NestedEinsum::Node { .. }));
-                assert!(matches!(
-                    &args[1],
-                    NestedEinsum::Leaf { tensor_index: 2 }
-                ));
+                assert!(matches!(&args[1], NestedEinsum::Leaf { tensor_index: 2 }));
             }
             _ => panic!("Expected Node at root"),
         }
@@ -399,14 +406,8 @@ mod tests {
         match &result.tree {
             NestedEinsum::Node { args, .. } => {
                 assert_eq!(args.len(), 2);
-                assert!(matches!(
-                    &args[0],
-                    NestedEinsum::Leaf { tensor_index: 0 }
-                ));
-                assert!(matches!(
-                    &args[1],
-                    NestedEinsum::Leaf { tensor_index: 1 }
-                ));
+                assert!(matches!(&args[0], NestedEinsum::Leaf { tensor_index: 0 }));
+                assert!(matches!(&args[1], NestedEinsum::Leaf { tensor_index: 1 }));
             }
             _ => panic!("Expected Node at root"),
         }

--- a/omeinsum-cli/tests/cli.rs
+++ b/omeinsum-cli/tests/cli.rs
@@ -38,7 +38,14 @@ fn test_optimize_to_file() {
     let out_path = out.path().to_str().unwrap().to_string();
 
     cmd()
-        .args(["optimize", "ij,jk->ik", "--sizes", "i=2,j=3,k=4", "-o", &out_path])
+        .args([
+            "optimize",
+            "ij,jk->ik",
+            "--sizes",
+            "i=2,j=3,k=4",
+            "-o",
+            &out_path,
+        ])
         .assert()
         .success();
 
@@ -205,7 +212,14 @@ fn test_optimize_then_contract_pipeline() {
     let topo_path = topo_file.path().to_str().unwrap().to_string();
 
     cmd()
-        .args(["optimize", "ij,jk->ik", "--sizes", "i=2,j=2,k=2", "-o", &topo_path])
+        .args([
+            "optimize",
+            "ij,jk->ik",
+            "--sizes",
+            "i=2,j=2,k=2",
+            "-o",
+            &topo_path,
+        ])
         .assert()
         .success();
 
@@ -366,7 +380,12 @@ fn test_contract_shape_mismatch() {
     );
 
     cmd()
-        .args(["contract", "--expr", "ij->ij", tensors.path().to_str().unwrap()])
+        .args([
+            "contract",
+            "--expr",
+            "ij->ij",
+            tensors.path().to_str().unwrap(),
+        ])
         .assert()
         .failure()
         .stderr(contains("doesn't match shape"));

--- a/omeinsum-cli/tests/cli.rs
+++ b/omeinsum-cli/tests/cli.rs
@@ -1,0 +1,496 @@
+use std::io::Write;
+
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::NamedTempFile;
+
+fn cmd() -> Command {
+    Command::cargo_bin("omeinsum").unwrap()
+}
+
+fn write_temp_json(content: &str) -> NamedTempFile {
+    let mut file = NamedTempFile::new().unwrap();
+    file.write_all(content.as_bytes()).unwrap();
+    file.flush().unwrap();
+    file
+}
+
+#[test]
+fn test_optimize_matmul() {
+    cmd()
+        .args([
+            "optimize",
+            "ij,jk->ik",
+            "--sizes",
+            "i=2,j=3,k=4",
+            "--pretty",
+            "true",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("schema_version"))
+        .stdout(contains("\"expression\": \"ij,jk->ik\""));
+}
+
+#[test]
+fn test_optimize_to_file() {
+    let out = NamedTempFile::new().unwrap();
+    let out_path = out.path().to_str().unwrap().to_string();
+
+    cmd()
+        .args(["optimize", "ij,jk->ik", "--sizes", "i=2,j=3,k=4", "-o", &out_path])
+        .assert()
+        .success();
+
+    let content = std::fs::read_to_string(&out_path).unwrap();
+    let topology: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(topology["schema_version"], 1);
+}
+
+#[test]
+fn test_contract_with_expr_f64() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 3], "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]},
+            {"shape": [3, 2], "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "contract",
+            "--expr",
+            "ij,jk->ik",
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["dtype"], "f64");
+    assert_eq!(result["shape"], serde_json::json!([2, 2]));
+    let data: Vec<f64> = serde_json::from_value(result["data"].clone()).unwrap();
+    assert_eq!(data, vec![22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn test_contract_with_expr_f32_row_major() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f32",
+        "order": "row_major",
+        "tensors": [
+            {"shape": [2, 3], "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]},
+            {"shape": [3, 2], "data": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "contract",
+            "--expr",
+            "ij,jk->ik",
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["dtype"], "f32");
+    assert_eq!(result["order"], "row_major");
+    assert_eq!(result["shape"], serde_json::json!([2, 2]));
+    let data: Vec<f64> = serde_json::from_value(result["data"].clone()).unwrap();
+    assert_eq!(data, vec![22.0, 28.0, 49.0, 64.0]);
+}
+
+#[test]
+fn test_contract_trace_c32() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "c32",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 2.0, -1.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "contract",
+            "--expr",
+            "ii->",
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["dtype"], "c32");
+    assert_eq!(result["shape"], serde_json::json!([]));
+    let data: Vec<f64> = serde_json::from_value(result["data"].clone()).unwrap();
+    assert_eq!(data, vec![3.0, 0.0]);
+}
+
+#[test]
+fn test_contract_transpose_c64_row_major() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "c64",
+        "order": "row_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 1.0, 2.0, -1.0, 3.0, 0.0, 4.0, 2.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "contract",
+            "--expr",
+            "ij->ji",
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["dtype"], "c64");
+    assert_eq!(result["order"], "row_major");
+    assert_eq!(result["shape"], serde_json::json!([2, 2]));
+    let data: Vec<f64> = serde_json::from_value(result["data"].clone()).unwrap();
+    assert_eq!(data, vec![1.0, 1.0, 3.0, 0.0, 2.0, -1.0, 4.0, 2.0]);
+}
+
+#[test]
+fn test_optimize_then_contract_pipeline() {
+    let topo_file = NamedTempFile::new().unwrap();
+    let topo_path = topo_file.path().to_str().unwrap().to_string();
+
+    cmd()
+        .args(["optimize", "ij,jk->ik", "--sizes", "i=2,j=2,k=2", "-o", &topo_path])
+        .assert()
+        .success();
+
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 0.0, 0.0, 1.0]},
+            {"shape": [2, 2], "data": [1.0, 0.0, 0.0, 1.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "contract",
+            "-t",
+            &topo_path,
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let data: Vec<f64> = serde_json::from_value(result["data"].clone()).unwrap();
+    assert_eq!(data, vec![1.0, 0.0, 0.0, 1.0]);
+}
+
+#[test]
+fn test_contract_scalar_output() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 0.0, 0.0, 1.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "contract",
+            "--expr",
+            "ii->",
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["shape"], serde_json::json!([]));
+    let data: Vec<f64> = serde_json::from_value(result["data"].clone()).unwrap();
+    assert_eq!(data, vec![2.0]);
+}
+
+#[test]
+fn test_contract_both_flags_error() {
+    let tensors = write_temp_json(r#"{"dtype":"f64","tensors":[]}"#);
+    cmd()
+        .args([
+            "contract",
+            "-t",
+            "topo.json",
+            "--expr",
+            "ij->ij",
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("Cannot specify both"));
+}
+
+#[test]
+fn test_contract_no_flags_error() {
+    let tensors = write_temp_json(r#"{"dtype":"f64","tensors":[]}"#);
+    cmd()
+        .args(["contract", tensors.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(contains("Must specify either"));
+}
+
+#[test]
+fn test_optimize_invalid_method_error() {
+    cmd()
+        .args([
+            "optimize",
+            "ij,jk->ik",
+            "--sizes",
+            "i=2,j=3,k=4",
+            "--method",
+            "badmethod",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("Unknown method"));
+}
+
+#[test]
+fn test_contract_invalid_schema_version() {
+    let topology = write_temp_json(
+        r#"{
+        "schema_version": 99,
+        "expression": "ij,jk->ik",
+        "label_map": {"i": 0, "j": 1, "k": 2},
+        "size_dict": {"0": 2, "1": 2, "2": 2},
+        "method": "greedy",
+        "tree": {"Leaf": {"tensor_index": 0}}
+    }"#,
+    );
+
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [{"shape": [2, 2], "data": [1.0, 0.0, 0.0, 1.0]}]
+    }"#,
+    );
+
+    cmd()
+        .args([
+            "contract",
+            "-t",
+            topology.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("schema_version"));
+}
+
+#[test]
+fn test_contract_shape_mismatch() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [{"shape": [2, 3], "data": [1.0, 2.0, 3.0]}]
+    }"#,
+    );
+
+    cmd()
+        .args(["contract", "--expr", "ij->ij", tensors.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(contains("doesn't match shape"));
+}
+
+#[test]
+fn test_contract_invalid_leaf_index_in_topology() {
+    let topology = write_temp_json(
+        r#"{
+        "schema_version": 1,
+        "expression": "i->i",
+        "label_map": {"i": 0},
+        "size_dict": {"0": 2},
+        "method": "greedy",
+        "tree": {"Leaf": {"tensor_index": 9}}
+    }"#,
+    );
+
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [{"shape": [2], "data": [1.0, 2.0]}]
+    }"#,
+    );
+
+    cmd()
+        .args([
+            "contract",
+            "-t",
+            topology.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("out of range"));
+}
+
+#[test]
+fn test_contract_non_binary_topology_error() {
+    let topology = write_temp_json(
+        r#"{
+        "schema_version": 1,
+        "expression": "i,j,k->i",
+        "label_map": {"i": 0, "j": 1, "k": 2},
+        "size_dict": {"0": 2, "1": 2, "2": 2},
+        "method": "greedy",
+        "tree": {
+            "Node": {
+                "args": [
+                    {"Leaf": {"tensor_index": 0}},
+                    {"Leaf": {"tensor_index": 1}},
+                    {"Leaf": {"tensor_index": 2}}
+                ],
+                "eins": {"ixs": [[0], [1], [2]], "iy": [0]}
+            }
+        }
+    }"#,
+    );
+
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2], "data": [1.0, 2.0]},
+            {"shape": [2], "data": [3.0, 4.0]},
+            {"shape": [2], "data": [5.0, 6.0]}
+        ]
+    }"#,
+    );
+
+    cmd()
+        .args([
+            "contract",
+            "-t",
+            topology.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("binary"));
+}
+
+#[test]
+fn test_contract_unknown_label_in_topology_error() {
+    let topology = write_temp_json(
+        r#"{
+        "schema_version": 1,
+        "expression": "i,j->ij",
+        "label_map": {"i": 0, "j": 1},
+        "size_dict": {"0": 2, "1": 2},
+        "method": "greedy",
+        "tree": {
+            "Node": {
+                "args": [
+                    {"Leaf": {"tensor_index": 0}},
+                    {"Leaf": {"tensor_index": 1}}
+                ],
+                "eins": {"ixs": [[0], [9]], "iy": [0, 9]}
+            }
+        }
+    }"#,
+    );
+
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2], "data": [1.0, 2.0]},
+            {"shape": [2], "data": [3.0, 4.0]}
+        ]
+    }"#,
+    );
+
+    cmd()
+        .args([
+            "contract",
+            "-t",
+            topology.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("unknown label index"));
+}

--- a/scripts/make_helpers.sh
+++ b/scripts/make_helpers.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+
+# --- Runner ---
+
+# Build a prompt for the given skill, adapting for claude vs codex.
+#   skill_prompt <skill-name> <claude-slash-command> [codex-description]
+# Examples:
+#   skill_prompt project-pipeline "/project-pipeline"       "pick and process the next Ready issue"
+#   skill_prompt project-pipeline "/project-pipeline 97"    "process GitHub issue 97"
+#   skill_prompt review-pipeline  "/review-pipeline"        "pick and process the next Review pool PR"
+skill_prompt() {
+    skill=$1
+    slash_cmd=$2
+    codex_desc=${3-}
+
+    if [ "${RUNNER:-codex}" = "claude" ]; then
+        echo "$slash_cmd"
+    else
+        echo "Use the repo-local skill at '.claude/skills/${skill}/SKILL.md'. Follow it to ${codex_desc}. Read the skill file directly instead of assuming Claude slash-command support."
+    fi
+}
+
+# Build a prompt and optionally append structured context for Codex.
+#   skill_prompt_with_context <skill> <slash-cmd> <codex-desc> <context-label> <context-json>
+skill_prompt_with_context() {
+    skill=$1
+    slash_cmd=$2
+    codex_desc=${3-}
+    context_label=${4-}
+    context_json=${5-}
+
+    base_prompt=$(skill_prompt "$skill" "$slash_cmd" "$codex_desc")
+    if [ "${RUNNER:-codex}" = "claude" ] || [ -z "$context_json" ]; then
+        echo "$base_prompt"
+    else
+        printf '%s\n\n## %s\n%s\n' "$base_prompt" "$context_label" "$context_json"
+    fi
+}
+
+# Run an agent with the configured runner (claude or codex).
+#   run_agent <log-file> <prompt>
+run_agent() {
+    output_file=$1
+    prompt=$2
+
+    if [ "${RUNNER:-codex}" = "claude" ]; then
+        claude --dangerously-skip-permissions \
+            --model "${CLAUDE_MODEL:-opus}" \
+            --verbose \
+            --output-format text \
+            --max-turns 500 \
+            -p "$prompt" 2>&1 | tee "$output_file"
+    else
+        codex exec \
+            --enable multi_agent \
+            -m "${CODEX_MODEL:-gpt-5.4}" \
+            -s danger-full-access \
+            "$prompt" 2>&1 | tee "$output_file"
+    fi
+}

--- a/src/backend/cpu/contract.rs
+++ b/src/backend/cpu/contract.rs
@@ -120,14 +120,14 @@ where
     let new_strides = compute_contiguous_strides(&new_shape);
     let old_size = shape.iter().product::<usize>().max(1);
 
-    for old_linear in 0..old_size {
+    for (old_linear, scalar) in data.iter().copied().enumerate().take(old_size) {
         // Compute old multi-index (column-major)
         let mut remaining = old_linear;
         let mut new_linear = 0usize;
         let mut new_dim = 0usize;
-        for i in 0..shape.len() {
-            let coord = remaining % shape[i];
-            remaining /= shape[i];
+        for (i, dim_size) in shape.iter().copied().enumerate() {
+            let coord = remaining % dim_size;
+            remaining /= dim_size;
             if !trace_positions.contains(&i) {
                 new_linear += coord * new_strides[new_dim];
                 new_dim += 1;
@@ -135,7 +135,7 @@ where
         }
 
         let acc = A::from_scalar(result[new_linear]);
-        let val = A::from_scalar(data[old_linear]);
+        let val = A::from_scalar(scalar);
         result[new_linear] = acc.add(val).to_scalar();
     }
 
@@ -171,8 +171,16 @@ where
     //    GEMM can only contract modes shared by both inputs. Single-input modes
     //    not in the output must be summed over (traced) before GEMM.
     let c_set: HashSet<i32> = modes_c.iter().copied().collect();
-    let left_trace: Vec<i32> = left.iter().filter(|m| !c_set.contains(m)).copied().collect();
-    let right_trace: Vec<i32> = right.iter().filter(|m| !c_set.contains(m)).copied().collect();
+    let left_trace: Vec<i32> = left
+        .iter()
+        .filter(|m| !c_set.contains(m))
+        .copied()
+        .collect();
+    let right_trace: Vec<i32> = right
+        .iter()
+        .filter(|m| !c_set.contains(m))
+        .copied()
+        .collect();
 
     let (a_data, a_shape, a_modes) = if !left_trace.is_empty() {
         reduce_trace_modes::<A>(&a_contig, shape_a, modes_a, &left_trace)
@@ -187,7 +195,11 @@ where
 
     // Free modes (left/right modes that ARE in the output)
     let left_free: Vec<i32> = left.iter().filter(|m| c_set.contains(m)).copied().collect();
-    let right_free: Vec<i32> = right.iter().filter(|m| c_set.contains(m)).copied().collect();
+    let right_free: Vec<i32> = right
+        .iter()
+        .filter(|m| c_set.contains(m))
+        .copied()
+        .collect();
 
     // 4. Compute dimension sizes (using reduced inputs)
     let batch_size = product_of_dims(&batch, &a_modes, &a_shape);
@@ -341,8 +353,16 @@ where
 
     // Handle trace modes (same as contract)
     let c_set: HashSet<i32> = modes_c.iter().copied().collect();
-    let left_trace: Vec<i32> = left.iter().filter(|m| !c_set.contains(m)).copied().collect();
-    let right_trace: Vec<i32> = right.iter().filter(|m| !c_set.contains(m)).copied().collect();
+    let left_trace: Vec<i32> = left
+        .iter()
+        .filter(|m| !c_set.contains(m))
+        .copied()
+        .collect();
+    let right_trace: Vec<i32> = right
+        .iter()
+        .filter(|m| !c_set.contains(m))
+        .copied()
+        .collect();
 
     let (a_data, a_shape, a_modes) = if !left_trace.is_empty() {
         reduce_trace_modes::<A>(&a_contig, shape_a, modes_a, &left_trace)
@@ -356,7 +376,11 @@ where
     };
 
     let left_free: Vec<i32> = left.iter().filter(|m| c_set.contains(m)).copied().collect();
-    let right_free: Vec<i32> = right.iter().filter(|m| c_set.contains(m)).copied().collect();
+    let right_free: Vec<i32> = right
+        .iter()
+        .filter(|m| c_set.contains(m))
+        .copied()
+        .collect();
 
     let batch_size = product_of_dims(&batch, &a_modes, &a_shape);
     let left_size = product_of_dims(&left_free, &a_modes, &a_shape);


### PR DESCRIPTION
## Summary
- add a new `omeinsum-cli` workspace crate with `optimize` and `contract` subcommands
- support flat and parenthesized einsum parsing, JSON topology/tensor/result formats, and row/column-major conversion
- add end-to-end CLI coverage for optimize/contract flows, multiple dtypes, storage orders, and malformed topology validation

## Test Plan
- cargo test --features tropical,parallel
- cargo test -p omeinsum-cli
- cargo clippy -p omeinsum-cli -- -D warnings
- cargo fmt -- --check
- make check
