### PR TITLE
feat(cli): add autodiff subcommand

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,7 +28,7 @@ cargo test --features tropical
 
 ## CLI (`omeinsum`)
 
-Install with `make cli`. Two subcommands:
+Install with `make cli`. Three subcommands:
 
 - **`omeinsum optimize`** — Optimize contraction order for an einsum expression.
   `omeinsum optimize "ij,jk->ik" --sizes "i=2,j=3,k=4"` (methods: `greedy`, `treesa`).
@@ -37,6 +37,10 @@ Install with `make cli`. Two subcommands:
 - **`omeinsum contract`** — Execute a tensor contraction from a tensors JSON file.
   Requires either `--topology <file>` (from optimize) or `--expr "(ij,jk),kl->il"`.
   Supported dtypes: f32, f64, c32, c64.
+- **`omeinsum autodiff`** — Execute a contraction and emit the forward result plus
+  gradients for each input tensor. Uses the same `--topology` or `--expr` contract
+  selection as `contract`. `--grad-output <file>` is optional for scalar outputs and
+  required for non-scalar outputs. Supported dtypes: f32, f64, c32, c64.
 
 ## Testing Conventions
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ cargo test --features tropical
 
 ## CLI Tool
 
-Install and use the `omeinsum` CLI for contraction optimization and execution without writing Rust code:
+Install and use the `omeinsum` CLI for contraction optimization, execution, and autodiff without writing Rust code:
 
 ```bash
 make cli                    # install to ~/.cargo/bin
 
 omeinsum optimize "ij,jk->ik" --sizes "i=2,j=3,k=2" -o topo.json
 omeinsum contract tensors.json -t topo.json
+omeinsum autodiff tensors.json --expr "ii->"
 ```
 
 See the [CLI documentation](https://tensor4all.github.io/omeinsum-rs/cli.html) for JSON formats, parenthesized expressions, and a full walkthrough.

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -1,6 +1,6 @@
 # CLI Tool
 
-The `omeinsum` command-line tool optimizes contraction order and executes tensor contractions from JSON files, without writing Rust code.
+The `omeinsum` command-line tool optimizes contraction order, executes tensor contractions, and computes autodiff gradients from JSON files, without writing Rust code.
 
 ## Installation
 
@@ -89,6 +89,29 @@ omeinsum contract tensors.json --expr "(ij,jk),kl->il"
 | `-o, --output` | no | Output file (default: stdout) |
 | `--pretty` | no | `true` or `false`; auto-detects TTY when omitted |
 
+### `omeinsum autodiff`
+
+Executes a contraction and emits both the forward result and gradients with respect to each input tensor. Requires either a pre-computed topology (`-t`) or an explicit contraction order (`--expr`), just like `contract`.
+
+```bash
+# Scalar output: seed defaults to 1
+omeinsum autodiff tensors.json --expr "ii->"
+
+# Non-scalar output: provide the output gradient seed explicitly
+omeinsum autodiff tensors.json --expr "ij,jk->ik" --grad-output dy.json -o autodiff.json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<tensors>` | yes | Path to tensors JSON file |
+| `-t, --topology` | one of `-t` or `--expr` | Topology JSON from `optimize` |
+| `--expr` | one of `-t` or `--expr` | Parenthesized expression (same parser as `contract`) |
+| `--grad-output` | required for non-scalar outputs | Gradient seed for the einsum output, using the Result JSON schema |
+| `-o, --output` | no | Output file (default: stdout) |
+| `--pretty` | no | `true` or `false`; auto-detects TTY when omitted |
+
+If `--grad-output` is omitted, the forward result must be scalar and the CLI uses a unit seed automatically. For complex dtypes, that unit seed is `1 + 0i`.
+
 ## Parenthesized Expressions
 
 The `--expr` flag specifies the contraction order using parentheses. Each pair of parentheses denotes one binary contraction step, executed inside-out:
@@ -142,6 +165,35 @@ If you don't know the best order, use `omeinsum optimize` to find one automatica
 
 The output uses the same `order` as the input. The `data` array is the flattened result tensor.
 
+### Output: Autodiff Result File
+
+Produced by `autodiff`:
+
+```json
+{
+  "dtype": "f64",
+  "order": "row_major",
+  "result": {
+    "shape": [2, 2],
+    "data": [19.0, 22.0, 43.0, 50.0]
+  },
+  "gradients": [
+    {
+      "input_index": 0,
+      "shape": [2, 2],
+      "data": [11.0, 15.0, 11.0, 15.0]
+    },
+    {
+      "input_index": 1,
+      "shape": [2, 2],
+      "data": [4.0, 4.0, 6.0, 6.0]
+    }
+  ]
+}
+```
+
+The output uses the same `dtype` and `order` as the input tensor file. Each gradient is tagged with its zero-based `input_index`.
+
 ### Intermediate: Topology File
 
 Produced by `optimize`, consumed by `contract -t`. You can treat it as a black box. The structure contains the original expression, a label-to-integer mapping, dimension sizes, and a binary contraction tree.
@@ -173,4 +225,16 @@ omeinsum contract /tmp/tensors.json -t /tmp/topology.json
 omeinsum contract /tmp/tensors.json --expr "(ij,jk)->ik"
 
 # Same output
+
+# 4. Differentiate the same contraction with an explicit output-gradient seed
+cat > /tmp/dy.json << 'EOF'
+{
+  "dtype": "f64",
+  "order": "row_major",
+  "shape": [2, 2],
+  "data": [1, 1, 1, 1]
+}
+EOF
+
+omeinsum autodiff /tmp/tensors.json --expr "ij,jk->ik" --grad-output /tmp/dy.json
 ```

--- a/omeinsum-cli/src/autodiff.rs
+++ b/omeinsum-cli/src/autodiff.rs
@@ -1,0 +1,214 @@
+use num_complex::{Complex32, Complex64};
+use omeinsum::algebra::Standard;
+use omeinsum::{cost_and_gradient, Algebra, BackendScalar, Cpu, Tensor};
+
+use crate::common::{
+    build_explicit_einsum, load_complex_result_tensor, load_complex_tensors,
+    load_real_result_tensor, load_real_tensors, read_tensors_file, serialize_complex_tensor_data,
+    serialize_real_tensor_data, write_json_output,
+};
+use crate::format::{AutodiffResultFile, Dtype, GradientFile, TensorsFile};
+
+/// Run the autodiff subcommand.
+pub fn run(
+    tensors_path: &str,
+    topology_path: Option<&str>,
+    expr: Option<&str>,
+    grad_output_path: Option<&str>,
+    output: Option<&str>,
+    pretty: Option<bool>,
+) -> Result<(), String> {
+    let tensors_file = read_tensors_file(tensors_path)?;
+
+    match tensors_file.dtype {
+        Dtype::F32 => run_real(
+            &tensors_file,
+            topology_path,
+            expr,
+            grad_output_path,
+            output,
+            pretty,
+            |value| value as f32,
+            |value| value as f64,
+        ),
+        Dtype::F64 => run_real(
+            &tensors_file,
+            topology_path,
+            expr,
+            grad_output_path,
+            output,
+            pretty,
+            |value| value,
+            |value| value,
+        ),
+        Dtype::C32 => run_complex(
+            &tensors_file,
+            topology_path,
+            expr,
+            grad_output_path,
+            output,
+            pretty,
+            |re, im| Complex32::new(re as f32, im as f32),
+            |value| (value.re as f64, value.im as f64),
+        ),
+        Dtype::C64 => run_complex(
+            &tensors_file,
+            topology_path,
+            expr,
+            grad_output_path,
+            output,
+            pretty,
+            Complex64::new,
+            |value| (value.re, value.im),
+        ),
+    }
+}
+
+fn run_real<T>(
+    tensors_file: &TensorsFile,
+    topology_path: Option<&str>,
+    expr: Option<&str>,
+    grad_output_path: Option<&str>,
+    output: Option<&str>,
+    pretty: Option<bool>,
+    from_f64: fn(f64) -> T,
+    to_f64: fn(T) -> f64,
+) -> Result<(), String>
+where
+    T: omeinsum::algebra::Scalar + BackendScalar<Cpu> + Copy,
+    Standard<T>: Algebra<Scalar = T, Index = u32>,
+{
+    let tensors = load_real_tensors(tensors_file, from_f64)?;
+    let tensor_refs: Vec<&Tensor<T, Cpu>> = tensors.iter().collect();
+    let ein = build_explicit_einsum(&tensor_refs, topology_path, expr)?;
+    let grad_output = match grad_output_path {
+        Some(path) => {
+            let grad_output =
+                load_real_result_tensor(path, tensors_file.dtype, tensors_file.order, from_f64)?;
+            validate_grad_output_shape(&ein, &grad_output)?;
+            Some(grad_output)
+        }
+        None => {
+            if !ein.iy.is_empty() {
+                return Err("Non-scalar output requires --grad-output".to_string());
+            }
+            None
+        }
+    };
+
+    let (result, gradients) =
+        cost_and_gradient::<Standard<T>, _, _>(&ein, &tensor_refs, grad_output.as_ref());
+
+    let result_data = serialize_real_tensor_data(&result, tensors_file.order, to_f64);
+    let gradients = gradients
+        .iter()
+        .enumerate()
+        .map(|(input_index, gradient)| {
+            let payload = serialize_real_tensor_data(gradient, tensors_file.order, to_f64);
+            GradientFile {
+                input_index,
+                shape: payload.shape,
+                data: payload.data,
+            }
+        })
+        .collect();
+
+    let result_file = AutodiffResultFile {
+        dtype: tensors_file.dtype,
+        order: tensors_file.order,
+        result: result_data,
+        gradients,
+    };
+    write_json_output(&result_file, output, pretty)
+}
+
+fn run_complex<T>(
+    tensors_file: &TensorsFile,
+    topology_path: Option<&str>,
+    expr: Option<&str>,
+    grad_output_path: Option<&str>,
+    output: Option<&str>,
+    pretty: Option<bool>,
+    make_complex: fn(f64, f64) -> T,
+    split_complex: fn(T) -> (f64, f64),
+) -> Result<(), String>
+where
+    T: omeinsum::algebra::Scalar + BackendScalar<Cpu> + Copy,
+    Standard<T>: Algebra<Scalar = T, Index = u32>,
+{
+    let tensors = load_complex_tensors(tensors_file, make_complex)?;
+    let tensor_refs: Vec<&Tensor<T, Cpu>> = tensors.iter().collect();
+    let ein = build_explicit_einsum(&tensor_refs, topology_path, expr)?;
+    let grad_output = match grad_output_path {
+        Some(path) => {
+            let grad_output = load_complex_result_tensor(
+                path,
+                tensors_file.dtype,
+                tensors_file.order,
+                make_complex,
+            )?;
+            validate_grad_output_shape(&ein, &grad_output)?;
+            Some(grad_output)
+        }
+        None => {
+            if !ein.iy.is_empty() {
+                return Err("Non-scalar output requires --grad-output".to_string());
+            }
+            None
+        }
+    };
+
+    let (result, gradients) =
+        cost_and_gradient::<Standard<T>, _, _>(&ein, &tensor_refs, grad_output.as_ref());
+
+    let result_data = serialize_complex_tensor_data(&result, tensors_file.order, split_complex);
+    let gradients = gradients
+        .iter()
+        .enumerate()
+        .map(|(input_index, gradient)| {
+            let payload =
+                serialize_complex_tensor_data(gradient, tensors_file.order, split_complex);
+            GradientFile {
+                input_index,
+                shape: payload.shape,
+                data: payload.data,
+            }
+        })
+        .collect();
+
+    let result_file = AutodiffResultFile {
+        dtype: tensors_file.dtype,
+        order: tensors_file.order,
+        result: result_data,
+        gradients,
+    };
+    write_json_output(&result_file, output, pretty)
+}
+
+fn validate_grad_output_shape<T>(
+    ein: &omeinsum::Einsum<usize>,
+    grad_output: &Tensor<T, Cpu>,
+) -> Result<(), String>
+where
+    T: omeinsum::algebra::Scalar,
+{
+    let expected_shape: Vec<usize> = ein
+        .iy
+        .iter()
+        .map(|label| {
+            *ein.size_dict
+                .get(label)
+                .expect("output label should have a dimension size")
+        })
+        .collect();
+
+    if grad_output.shape() != expected_shape.as_slice() {
+        return Err(format!(
+            "grad_output shape {:?} doesn't match output shape {:?}",
+            grad_output.shape(),
+            expected_shape
+        ));
+    }
+
+    Ok(())
+}

--- a/omeinsum-cli/src/common.rs
+++ b/omeinsum-cli/src/common.rs
@@ -263,6 +263,7 @@ where
             tensors.len()
         ));
     }
+    validate_size_dict_labels(&parsed.ixs, &parsed.iy, &size_dict)?;
 
     let mut ein = Einsum::new(parsed.ixs, parsed.iy, size_dict);
     ein.set_contraction_tree(topology.tree);
@@ -324,6 +325,23 @@ fn validate_shape(data: &[f64], shape: &[usize], is_complex: bool) -> Result<(),
             expected_len
         ));
     }
+    Ok(())
+}
+
+fn validate_size_dict_labels(
+    ixs: &[Vec<usize>],
+    iy: &[usize],
+    size_dict: &HashMap<usize, usize>,
+) -> Result<(), String> {
+    for &label in ixs.iter().flatten().chain(iy.iter()) {
+        if !size_dict.contains_key(&label) {
+            return Err(format!(
+                "Missing size for label index {} referenced by topology expression",
+                label
+            ));
+        }
+    }
+
     Ok(())
 }
 

--- a/omeinsum-cli/src/common.rs
+++ b/omeinsum-cli/src/common.rs
@@ -1,0 +1,445 @@
+use std::collections::HashMap;
+use std::io::{self, IsTerminal, Write};
+
+use omeco::NestedEinsum;
+use omeinsum::algebra::Scalar;
+use omeinsum::{BackendScalar, Cpu, Einsum, Tensor};
+use serde::Serialize;
+
+use crate::format::{
+    col_to_row_major, row_to_col_major, Dtype, ResultFile, StorageOrder, TensorDataFile,
+    TensorsFile, TopologyFile,
+};
+use crate::parse::{parse_flat, parse_parenthesized};
+
+pub(crate) fn validate_execution_source(
+    topology_path: Option<&str>,
+    expr: Option<&str>,
+) -> Result<(), String> {
+    match (topology_path, expr) {
+        (Some(_), Some(_)) => Err("Cannot specify both -t and --expr".to_string()),
+        (None, None) => Err("Must specify either -t or --expr".to_string()),
+        _ => Ok(()),
+    }
+}
+
+pub(crate) fn read_tensors_file(path: &str) -> Result<TensorsFile, String> {
+    let json =
+        std::fs::read_to_string(path).map_err(|err| format!("Failed to read '{path}': {err}"))?;
+    serde_json::from_str(&json).map_err(|err| format!("Failed to parse tensors JSON: {err}"))
+}
+
+pub(crate) fn load_real_tensors<T>(
+    tensors_file: &TensorsFile,
+    from_f64: fn(f64) -> T,
+) -> Result<Vec<Tensor<T, Cpu>>, String>
+where
+    T: Scalar + BackendScalar<Cpu>,
+{
+    tensors_file
+        .tensors
+        .iter()
+        .map(|entry| {
+            validate_shape(&entry.data, &entry.shape, false)?;
+            let col_major_data = match tensors_file.order {
+                StorageOrder::RowMajor => row_to_col_major(&entry.data, &entry.shape),
+                StorageOrder::ColMajor => entry.data.clone(),
+            };
+            let data: Vec<T> = col_major_data.into_iter().map(from_f64).collect();
+            Ok(Tensor::<T, Cpu>::from_data(&data, &entry.shape))
+        })
+        .collect()
+}
+
+pub(crate) fn load_complex_tensors<T>(
+    tensors_file: &TensorsFile,
+    make_complex: fn(f64, f64) -> T,
+) -> Result<Vec<Tensor<T, Cpu>>, String>
+where
+    T: Scalar + BackendScalar<Cpu>,
+{
+    tensors_file
+        .tensors
+        .iter()
+        .map(|entry| {
+            validate_shape(&entry.data, &entry.shape, true)?;
+            let col_major_data = match tensors_file.order {
+                StorageOrder::RowMajor => row_to_col_major_interleaved(&entry.data, &entry.shape),
+                StorageOrder::ColMajor => entry.data.clone(),
+            };
+            let data = interleaved_to_complex(&col_major_data, make_complex);
+            Ok(Tensor::<T, Cpu>::from_data(&data, &entry.shape))
+        })
+        .collect()
+}
+
+pub(crate) fn load_real_result_tensor<T>(
+    path: &str,
+    expected_dtype: Dtype,
+    expected_order: StorageOrder,
+    from_f64: fn(f64) -> T,
+) -> Result<Tensor<T, Cpu>, String>
+where
+    T: Scalar + BackendScalar<Cpu>,
+{
+    let result_file = read_result_file(path)?;
+    validate_result_metadata(&result_file, path, expected_dtype, expected_order)?;
+    validate_shape(&result_file.data, &result_file.shape, false)?;
+
+    let col_major_data = match result_file.order {
+        StorageOrder::RowMajor => row_to_col_major(&result_file.data, &result_file.shape),
+        StorageOrder::ColMajor => result_file.data,
+    };
+    let data: Vec<T> = col_major_data.into_iter().map(from_f64).collect();
+    Ok(Tensor::<T, Cpu>::from_data(&data, &result_file.shape))
+}
+
+pub(crate) fn load_complex_result_tensor<T>(
+    path: &str,
+    expected_dtype: Dtype,
+    expected_order: StorageOrder,
+    make_complex: fn(f64, f64) -> T,
+) -> Result<Tensor<T, Cpu>, String>
+where
+    T: Scalar + BackendScalar<Cpu>,
+{
+    let result_file = read_result_file(path)?;
+    validate_result_metadata(&result_file, path, expected_dtype, expected_order)?;
+    validate_shape(&result_file.data, &result_file.shape, true)?;
+
+    let col_major_data = match result_file.order {
+        StorageOrder::RowMajor => {
+            row_to_col_major_interleaved(&result_file.data, &result_file.shape)
+        }
+        StorageOrder::ColMajor => result_file.data,
+    };
+    let data = interleaved_to_complex(&col_major_data, make_complex);
+    Ok(Tensor::<T, Cpu>::from_data(&data, &result_file.shape))
+}
+
+pub(crate) fn serialize_real_tensor_data<T>(
+    tensor: &Tensor<T, Cpu>,
+    order: StorageOrder,
+    to_f64: fn(T) -> f64,
+) -> TensorDataFile
+where
+    T: Scalar + BackendScalar<Cpu> + Copy,
+{
+    let mut data: Vec<f64> = tensor.to_vec().into_iter().map(to_f64).collect();
+    if order == StorageOrder::RowMajor {
+        data = col_to_row_major(&data, tensor.shape());
+    }
+
+    TensorDataFile {
+        shape: tensor.shape().to_vec(),
+        data,
+    }
+}
+
+pub(crate) fn serialize_complex_tensor_data<T>(
+    tensor: &Tensor<T, Cpu>,
+    order: StorageOrder,
+    split_complex: fn(T) -> (f64, f64),
+) -> TensorDataFile
+where
+    T: Scalar + BackendScalar<Cpu> + Copy,
+{
+    let mut data = complex_to_interleaved(&tensor.to_vec(), split_complex);
+    if order == StorageOrder::RowMajor {
+        data = col_to_row_major_interleaved(&data, tensor.shape());
+    }
+
+    TensorDataFile {
+        shape: tensor.shape().to_vec(),
+        data,
+    }
+}
+
+pub(crate) fn build_explicit_einsum<T>(
+    tensors: &[&Tensor<T, Cpu>],
+    topology_path: Option<&str>,
+    expr: Option<&str>,
+) -> Result<Einsum<usize>, String>
+where
+    T: Scalar,
+{
+    validate_execution_source(topology_path, expr)?;
+
+    match topology_path {
+        Some(path) => load_einsum_from_topology(tensors, path),
+        None => load_einsum_from_expr(tensors, expr.expect("validated expression source")),
+    }
+}
+
+pub(crate) fn write_json_output<S: Serialize>(
+    value: &S,
+    output: Option<&str>,
+    pretty: Option<bool>,
+) -> Result<(), String> {
+    let use_pretty = pretty.unwrap_or_else(|| io::stdout().is_terminal());
+    let json = if use_pretty {
+        serde_json::to_string_pretty(value)
+    } else {
+        serde_json::to_string(value)
+    }
+    .map_err(|err| format!("JSON serialization failed: {err}"))?;
+
+    match output {
+        Some(path) => {
+            std::fs::write(path, &json).map_err(|err| format!("Failed to write '{path}': {err}"))?
+        }
+        None => {
+            let stdout = io::stdout();
+            let mut handle = stdout.lock();
+            writeln!(handle, "{json}").map_err(|err| format!("Failed to write stdout: {err}"))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn read_result_file(path: &str) -> Result<ResultFile, String> {
+    let json =
+        std::fs::read_to_string(path).map_err(|err| format!("Failed to read '{path}': {err}"))?;
+    serde_json::from_str(&json).map_err(|err| format!("Failed to parse result JSON: {err}"))
+}
+
+fn validate_result_metadata(
+    result_file: &ResultFile,
+    path: &str,
+    expected_dtype: Dtype,
+    expected_order: StorageOrder,
+) -> Result<(), String> {
+    if result_file.dtype != expected_dtype {
+        return Err(format!(
+            "grad_output dtype {:?} in '{path}' doesn't match tensors dtype {:?}",
+            result_file.dtype, expected_dtype
+        ));
+    }
+    if result_file.order != expected_order {
+        return Err(format!(
+            "grad_output order {:?} in '{path}' doesn't match tensors order {:?}",
+            result_file.order, expected_order
+        ));
+    }
+    Ok(())
+}
+
+fn load_einsum_from_topology<T>(
+    tensors: &[&Tensor<T, Cpu>],
+    topology_path: &str,
+) -> Result<Einsum<usize>, String>
+where
+    T: Scalar,
+{
+    let topology_json = std::fs::read_to_string(topology_path)
+        .map_err(|err| format!("Failed to read '{topology_path}': {err}"))?;
+    let topology: TopologyFile = serde_json::from_str(&topology_json)
+        .map_err(|err| format!("Failed to parse topology JSON: {err}"))?;
+
+    if topology.schema_version != 1 {
+        return Err(format!(
+            "Unsupported schema_version {}, expected 1",
+            topology.schema_version
+        ));
+    }
+
+    let size_dict: HashMap<usize, usize> = topology
+        .size_dict
+        .iter()
+        .map(|(key, value)| {
+            key.parse::<usize>()
+                .map(|idx| (idx, *value))
+                .map_err(|_| format!("Invalid size_dict key '{key}'"))
+        })
+        .collect::<Result<_, _>>()?;
+    validate_topology_tree(&topology.tree, tensors.len(), &size_dict)?;
+
+    let parsed = parse_flat(&topology.expression)?;
+    if tensors.len() != parsed.ixs.len() {
+        return Err(format!(
+            "Expression expects {} tensors but received {}",
+            parsed.ixs.len(),
+            tensors.len()
+        ));
+    }
+
+    let mut ein = Einsum::new(parsed.ixs, parsed.iy, size_dict);
+    ein.set_contraction_tree(topology.tree);
+    Ok(ein)
+}
+
+fn load_einsum_from_expr<T>(
+    tensors: &[&Tensor<T, Cpu>],
+    expr: &str,
+) -> Result<Einsum<usize>, String>
+where
+    T: Scalar,
+{
+    let parsed = parse_parenthesized(expr)?;
+    if tensors.len() != parsed.ixs.len() {
+        return Err(format!(
+            "Expression expects {} tensors but received {}",
+            parsed.ixs.len(),
+            tensors.len()
+        ));
+    }
+
+    let mut size_dict = HashMap::new();
+    for (tensor, labels) in tensors.iter().zip(parsed.ixs.iter()) {
+        if tensor.ndim() != labels.len() {
+            return Err(format!(
+                "Tensor has {} dims but expression specifies {} labels",
+                tensor.ndim(),
+                labels.len()
+            ));
+        }
+
+        for (dim, label) in labels.iter().copied().enumerate() {
+            let size = tensor.shape()[dim];
+            if let Some(existing) = size_dict.insert(label, size) {
+                if existing != size {
+                    return Err(format!(
+                        "Inconsistent size for label index {}: {} vs {}",
+                        label, existing, size
+                    ));
+                }
+            }
+        }
+    }
+
+    let mut ein = Einsum::new(parsed.ixs, parsed.iy, size_dict);
+    ein.set_contraction_tree(parsed.tree);
+    Ok(ein)
+}
+
+fn validate_shape(data: &[f64], shape: &[usize], is_complex: bool) -> Result<(), String> {
+    let numel: usize = shape.iter().product();
+    let expected_len = if is_complex { numel * 2 } else { numel };
+    if data.len() != expected_len {
+        return Err(format!(
+            "Data length {} doesn't match shape {:?} (expected {})",
+            data.len(),
+            shape,
+            expected_len
+        ));
+    }
+    Ok(())
+}
+
+fn validate_topology_tree(
+    tree: &NestedEinsum<usize>,
+    num_tensors: usize,
+    size_dict: &HashMap<usize, usize>,
+) -> Result<(), String> {
+    match tree {
+        NestedEinsum::Leaf { tensor_index } => {
+            if *tensor_index >= num_tensors {
+                return Err(format!(
+                    "Topology leaf tensor_index {} out of range for {} tensors",
+                    tensor_index, num_tensors
+                ));
+            }
+            Ok(())
+        }
+        NestedEinsum::Node { args, eins } => {
+            if args.len() != 2 {
+                return Err(format!(
+                    "Topology tree must be binary, found node with {} children",
+                    args.len()
+                ));
+            }
+
+            for label in eins.ixs.iter().flatten().chain(eins.iy.iter()) {
+                if !size_dict.contains_key(label) {
+                    return Err(format!("Topology references unknown label index {}", label));
+                }
+            }
+
+            for arg in args {
+                validate_topology_tree(arg, num_tensors, size_dict)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn interleaved_to_complex<T>(data: &[f64], make_complex: fn(f64, f64) -> T) -> Vec<T> {
+    data.chunks_exact(2)
+        .map(|pair| make_complex(pair[0], pair[1]))
+        .collect()
+}
+
+fn complex_to_interleaved<T>(data: &[T], split_complex: fn(T) -> (f64, f64)) -> Vec<f64>
+where
+    T: Copy,
+{
+    let mut result = Vec::with_capacity(data.len() * 2);
+    for value in data.iter().copied() {
+        let (re, im) = split_complex(value);
+        result.push(re);
+        result.push(im);
+    }
+    result
+}
+
+fn row_to_col_major_interleaved(data: &[f64], shape: &[usize]) -> Vec<f64> {
+    if shape.len() <= 1 {
+        return data.to_vec();
+    }
+
+    let indices = compute_row_to_col_indices(shape);
+    let mut result = vec![0.0; data.len()];
+    for (row_idx, col_idx) in indices.into_iter().enumerate() {
+        result[col_idx * 2] = data[row_idx * 2];
+        result[col_idx * 2 + 1] = data[row_idx * 2 + 1];
+    }
+    result
+}
+
+fn col_to_row_major_interleaved(data: &[f64], shape: &[usize]) -> Vec<f64> {
+    if shape.len() <= 1 {
+        return data.to_vec();
+    }
+
+    let indices = compute_row_to_col_indices(shape);
+    let mut result = vec![0.0; data.len()];
+    for (row_idx, col_idx) in indices.into_iter().enumerate() {
+        result[row_idx * 2] = data[col_idx * 2];
+        result[row_idx * 2 + 1] = data[col_idx * 2 + 1];
+    }
+    result
+}
+
+fn compute_row_to_col_indices(shape: &[usize]) -> Vec<usize> {
+    let numel: usize = shape.iter().product();
+    let col_strides = col_major_strides(shape);
+
+    (0..numel)
+        .map(|row_idx| {
+            let coords = row_major_coords(row_idx, shape);
+            coords
+                .into_iter()
+                .enumerate()
+                .map(|(dim, coord)| coord * col_strides[dim])
+                .sum()
+        })
+        .collect()
+}
+
+fn row_major_coords(mut linear_idx: usize, shape: &[usize]) -> Vec<usize> {
+    let mut coords = vec![0usize; shape.len()];
+    for dim in (0..shape.len()).rev() {
+        coords[dim] = linear_idx % shape[dim];
+        linear_idx /= shape[dim];
+    }
+    coords
+}
+
+fn col_major_strides(shape: &[usize]) -> Vec<usize> {
+    let mut strides = vec![1usize; shape.len()];
+    for dim in 1..shape.len() {
+        strides[dim] = strides[dim - 1] * shape[dim - 1];
+    }
+    strides
+}

--- a/omeinsum-cli/src/contract.rs
+++ b/omeinsum-cli/src/contract.rs
@@ -1,15 +1,12 @@
-use std::collections::HashMap;
-use std::io::{self, IsTerminal, Write};
-
 use num_complex::{Complex32, Complex64};
-use omeco::NestedEinsum;
 use omeinsum::algebra::Standard;
-use omeinsum::{Algebra, BackendScalar, Cpu, Einsum, Tensor};
+use omeinsum::{Algebra, BackendScalar, Cpu, Tensor};
 
-use crate::format::{
-    col_to_row_major, row_to_col_major, Dtype, ResultFile, StorageOrder, TensorsFile, TopologyFile,
+use crate::common::{
+    build_explicit_einsum, load_complex_tensors, load_real_tensors, read_tensors_file,
+    serialize_complex_tensor_data, serialize_real_tensor_data, write_json_output,
 };
-use crate::parse::{parse_flat, parse_parenthesized};
+use crate::format::{Dtype, ResultFile, TensorsFile};
 
 /// Run the contract subcommand.
 pub fn run(
@@ -19,16 +16,7 @@ pub fn run(
     output: Option<&str>,
     pretty: Option<bool>,
 ) -> Result<(), String> {
-    match (topology_path, expr) {
-        (Some(_), Some(_)) => return Err("Cannot specify both -t and --expr".to_string()),
-        (None, None) => return Err("Must specify either -t or --expr".to_string()),
-        _ => {}
-    }
-
-    let tensors_json = std::fs::read_to_string(tensors_path)
-        .map_err(|err| format!("Failed to read '{tensors_path}': {err}"))?;
-    let tensors_file: TensorsFile = serde_json::from_str(&tensors_json)
-        .map_err(|err| format!("Failed to parse tensors JSON: {err}"))?;
+    let tensors_file = read_tensors_file(tensors_path)?;
 
     match tensors_file.dtype {
         Dtype::F32 => run_real(
@@ -83,38 +71,19 @@ where
     T: omeinsum::algebra::Scalar + BackendScalar<Cpu>,
     Standard<T>: Algebra<Scalar = T, Index = u32>,
 {
-    let tensors: Vec<Tensor<T, Cpu>> = tensors_file
-        .tensors
-        .iter()
-        .map(|entry| {
-            validate_shape(&entry.data, &entry.shape, false)?;
-            let col_major_data = match tensors_file.order {
-                StorageOrder::RowMajor => row_to_col_major(&entry.data, &entry.shape),
-                StorageOrder::ColMajor => entry.data.clone(),
-            };
-            let data: Vec<T> = col_major_data.into_iter().map(from_f64).collect();
-            Ok(Tensor::<T, Cpu>::from_data(&data, &entry.shape))
-        })
-        .collect::<Result<_, String>>()?;
-
+    let tensors = load_real_tensors(tensors_file, from_f64)?;
     let tensor_refs: Vec<&Tensor<T, Cpu>> = tensors.iter().collect();
-    let result = match topology_path {
-        Some(path) => execute_with_topology(&tensor_refs, path)?,
-        None => execute_with_expr(&tensor_refs, expr.unwrap())?,
-    };
-
-    let mut data: Vec<f64> = result.to_vec().into_iter().map(to_f64).collect();
-    if tensors_file.order == StorageOrder::RowMajor {
-        data = col_to_row_major(&data, result.shape());
-    }
+    let ein = build_explicit_einsum(&tensor_refs, topology_path, expr)?;
+    let result = ein.execute::<Standard<T>, T, Cpu>(&tensor_refs);
+    let result_data = serialize_real_tensor_data(&result, tensors_file.order, to_f64);
 
     let result_file = ResultFile {
         dtype: tensors_file.dtype,
         order: tensors_file.order,
-        shape: result.shape().to_vec(),
-        data,
+        shape: result_data.shape,
+        data: result_data.data,
     };
-    write_output(&result_file, output, pretty)
+    write_json_output(&result_file, output, pretty)
 }
 
 fn run_complex<T>(
@@ -130,281 +99,17 @@ where
     T: omeinsum::algebra::Scalar + BackendScalar<Cpu>,
     Standard<T>: Algebra<Scalar = T, Index = u32>,
 {
-    let tensors: Vec<Tensor<T, Cpu>> = tensors_file
-        .tensors
-        .iter()
-        .map(|entry| {
-            validate_shape(&entry.data, &entry.shape, true)?;
-            let col_major_data = match tensors_file.order {
-                StorageOrder::RowMajor => row_to_col_major_interleaved(&entry.data, &entry.shape),
-                StorageOrder::ColMajor => entry.data.clone(),
-            };
-            let data = interleaved_to_complex(&col_major_data, make_complex);
-            Ok(Tensor::<T, Cpu>::from_data(&data, &entry.shape))
-        })
-        .collect::<Result<_, String>>()?;
-
+    let tensors = load_complex_tensors(tensors_file, make_complex)?;
     let tensor_refs: Vec<&Tensor<T, Cpu>> = tensors.iter().collect();
-    let result = match topology_path {
-        Some(path) => execute_with_topology(&tensor_refs, path)?,
-        None => execute_with_expr(&tensor_refs, expr.unwrap())?,
-    };
-
-    let mut data = complex_to_interleaved(&result.to_vec(), split_complex);
-    if tensors_file.order == StorageOrder::RowMajor {
-        data = col_to_row_major_interleaved(&data, result.shape());
-    }
+    let ein = build_explicit_einsum(&tensor_refs, topology_path, expr)?;
+    let result = ein.execute::<Standard<T>, T, Cpu>(&tensor_refs);
+    let result_data = serialize_complex_tensor_data(&result, tensors_file.order, split_complex);
 
     let result_file = ResultFile {
         dtype: tensors_file.dtype,
         order: tensors_file.order,
-        shape: result.shape().to_vec(),
-        data,
+        shape: result_data.shape,
+        data: result_data.data,
     };
-    write_output(&result_file, output, pretty)
-}
-
-fn execute_with_topology<T>(
-    tensors: &[&Tensor<T, Cpu>],
-    topology_path: &str,
-) -> Result<Tensor<T, Cpu>, String>
-where
-    T: omeinsum::algebra::Scalar + BackendScalar<Cpu>,
-    Standard<T>: Algebra<Scalar = T, Index = u32>,
-{
-    let topology_json = std::fs::read_to_string(topology_path)
-        .map_err(|err| format!("Failed to read '{topology_path}': {err}"))?;
-    let topology: TopologyFile = serde_json::from_str(&topology_json)
-        .map_err(|err| format!("Failed to parse topology JSON: {err}"))?;
-
-    if topology.schema_version != 1 {
-        return Err(format!(
-            "Unsupported schema_version {}, expected 1",
-            topology.schema_version
-        ));
-    }
-
-    let size_dict: HashMap<usize, usize> = topology
-        .size_dict
-        .iter()
-        .map(|(key, value)| {
-            key.parse::<usize>()
-                .map(|idx| (idx, *value))
-                .map_err(|_| format!("Invalid size_dict key '{key}'"))
-        })
-        .collect::<Result<_, _>>()?;
-    validate_topology_tree(&topology.tree, tensors.len(), &size_dict)?;
-
-    let parsed = parse_flat(&topology.expression)?;
-    if tensors.len() != parsed.ixs.len() {
-        return Err(format!(
-            "Expression expects {} tensors but received {}",
-            parsed.ixs.len(),
-            tensors.len()
-        ));
-    }
-
-    let mut ein = Einsum::new(parsed.ixs, parsed.iy, size_dict);
-    ein.set_contraction_tree(topology.tree);
-    Ok(ein.execute::<Standard<T>, T, Cpu>(tensors))
-}
-
-fn execute_with_expr<T>(tensors: &[&Tensor<T, Cpu>], expr: &str) -> Result<Tensor<T, Cpu>, String>
-where
-    T: omeinsum::algebra::Scalar + BackendScalar<Cpu>,
-    Standard<T>: Algebra<Scalar = T, Index = u32>,
-{
-    let parsed = parse_parenthesized(expr)?;
-    if tensors.len() != parsed.ixs.len() {
-        return Err(format!(
-            "Expression expects {} tensors but received {}",
-            parsed.ixs.len(),
-            tensors.len()
-        ));
-    }
-
-    let mut size_dict = HashMap::new();
-    for (tensor, labels) in tensors.iter().zip(parsed.ixs.iter()) {
-        if tensor.ndim() != labels.len() {
-            return Err(format!(
-                "Tensor has {} dims but expression specifies {} labels",
-                tensor.ndim(),
-                labels.len()
-            ));
-        }
-
-        for (dim, label) in labels.iter().copied().enumerate() {
-            let size = tensor.shape()[dim];
-            if let Some(existing) = size_dict.insert(label, size) {
-                if existing != size {
-                    return Err(format!(
-                        "Inconsistent size for label index {}: {} vs {}",
-                        label, existing, size
-                    ));
-                }
-            }
-        }
-    }
-
-    let mut ein = Einsum::new(parsed.ixs, parsed.iy, size_dict);
-    ein.set_contraction_tree(parsed.tree);
-    Ok(ein.execute::<Standard<T>, T, Cpu>(tensors))
-}
-
-fn validate_shape(data: &[f64], shape: &[usize], is_complex: bool) -> Result<(), String> {
-    let numel: usize = shape.iter().product();
-    let expected_len = if is_complex { numel * 2 } else { numel };
-    if data.len() != expected_len {
-        return Err(format!(
-            "Data length {} doesn't match shape {:?} (expected {})",
-            data.len(),
-            shape,
-            expected_len
-        ));
-    }
-    Ok(())
-}
-
-fn validate_topology_tree(
-    tree: &NestedEinsum<usize>,
-    num_tensors: usize,
-    size_dict: &HashMap<usize, usize>,
-) -> Result<(), String> {
-    match tree {
-        NestedEinsum::Leaf { tensor_index } => {
-            if *tensor_index >= num_tensors {
-                return Err(format!(
-                    "Topology leaf tensor_index {} out of range for {} tensors",
-                    tensor_index, num_tensors
-                ));
-            }
-            Ok(())
-        }
-        NestedEinsum::Node { args, eins } => {
-            if args.len() != 2 {
-                return Err(format!(
-                    "Topology tree must be binary, found node with {} children",
-                    args.len()
-                ));
-            }
-
-            for label in eins.ixs.iter().flatten().chain(eins.iy.iter()) {
-                if !size_dict.contains_key(label) {
-                    return Err(format!("Topology references unknown label index {}", label));
-                }
-            }
-
-            for arg in args {
-                validate_topology_tree(arg, num_tensors, size_dict)?;
-            }
-            Ok(())
-        }
-    }
-}
-
-fn interleaved_to_complex<T>(data: &[f64], make_complex: fn(f64, f64) -> T) -> Vec<T> {
-    data.chunks_exact(2)
-        .map(|pair| make_complex(pair[0], pair[1]))
-        .collect()
-}
-
-fn complex_to_interleaved<T>(data: &[T], split_complex: fn(T) -> (f64, f64)) -> Vec<f64>
-where
-    T: Copy,
-{
-    let mut result = Vec::with_capacity(data.len() * 2);
-    for value in data.iter().copied() {
-        let (re, im) = split_complex(value);
-        result.push(re);
-        result.push(im);
-    }
-    result
-}
-
-fn row_to_col_major_interleaved(data: &[f64], shape: &[usize]) -> Vec<f64> {
-    if shape.len() <= 1 {
-        return data.to_vec();
-    }
-
-    let indices = compute_row_to_col_indices(shape);
-    let mut result = vec![0.0; data.len()];
-    for (row_idx, col_idx) in indices.into_iter().enumerate() {
-        result[col_idx * 2] = data[row_idx * 2];
-        result[col_idx * 2 + 1] = data[row_idx * 2 + 1];
-    }
-    result
-}
-
-fn col_to_row_major_interleaved(data: &[f64], shape: &[usize]) -> Vec<f64> {
-    if shape.len() <= 1 {
-        return data.to_vec();
-    }
-
-    let indices = compute_row_to_col_indices(shape);
-    let mut result = vec![0.0; data.len()];
-    for (row_idx, col_idx) in indices.into_iter().enumerate() {
-        result[row_idx * 2] = data[col_idx * 2];
-        result[row_idx * 2 + 1] = data[col_idx * 2 + 1];
-    }
-    result
-}
-
-fn compute_row_to_col_indices(shape: &[usize]) -> Vec<usize> {
-    let numel: usize = shape.iter().product();
-    let col_strides = col_major_strides(shape);
-
-    (0..numel)
-        .map(|row_idx| {
-            let coords = row_major_coords(row_idx, shape);
-            coords
-                .into_iter()
-                .enumerate()
-                .map(|(dim, coord)| coord * col_strides[dim])
-                .sum()
-        })
-        .collect()
-}
-
-fn row_major_coords(mut linear_idx: usize, shape: &[usize]) -> Vec<usize> {
-    let mut coords = vec![0usize; shape.len()];
-    for dim in (0..shape.len()).rev() {
-        coords[dim] = linear_idx % shape[dim];
-        linear_idx /= shape[dim];
-    }
-    coords
-}
-
-fn col_major_strides(shape: &[usize]) -> Vec<usize> {
-    let mut strides = vec![1usize; shape.len()];
-    for dim in 1..shape.len() {
-        strides[dim] = strides[dim - 1] * shape[dim - 1];
-    }
-    strides
-}
-
-fn write_output(
-    result: &ResultFile,
-    output: Option<&str>,
-    pretty: Option<bool>,
-) -> Result<(), String> {
-    let use_pretty = pretty.unwrap_or_else(|| io::stdout().is_terminal());
-    let json = if use_pretty {
-        serde_json::to_string_pretty(result)
-    } else {
-        serde_json::to_string(result)
-    }
-    .map_err(|err| format!("JSON serialization failed: {err}"))?;
-
-    match output {
-        Some(path) => {
-            std::fs::write(path, &json).map_err(|err| format!("Failed to write '{path}': {err}"))?
-        }
-        None => {
-            let stdout = io::stdout();
-            let mut handle = stdout.lock();
-            writeln!(handle, "{json}").map_err(|err| format!("Failed to write stdout: {err}"))?;
-        }
-    }
-
-    Ok(())
+    write_json_output(&result_file, output, pretty)
 }

--- a/omeinsum-cli/src/format.rs
+++ b/omeinsum-cli/src/format.rs
@@ -61,6 +61,30 @@ pub struct ResultFile {
     pub data: Vec<f64>,
 }
 
+/// Tensor payload used inside higher-level result bundles.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TensorDataFile {
+    pub shape: Vec<usize>,
+    pub data: Vec<f64>,
+}
+
+/// A gradient tensor paired with its input position.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GradientFile {
+    pub input_index: usize,
+    pub shape: Vec<usize>,
+    pub data: Vec<f64>,
+}
+
+/// The autodiff JSON output schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AutodiffResultFile {
+    pub dtype: Dtype,
+    pub order: StorageOrder,
+    pub result: TensorDataFile,
+    pub gradients: Vec<GradientFile>,
+}
+
 /// Convert row-major flat data to column-major for a given shape.
 pub fn row_to_col_major(data: &[f64], shape: &[usize]) -> Vec<f64> {
     if shape.len() <= 1 {

--- a/omeinsum-cli/src/main.rs
+++ b/omeinsum-cli/src/main.rs
@@ -1,5 +1,7 @@
 use clap::{Parser, Subcommand};
 
+mod autodiff;
+mod common;
 mod contract;
 mod format;
 mod optimize;
@@ -94,6 +96,31 @@ enum Commands {
         #[arg(long)]
         pretty: Option<bool>,
     },
+    /// Execute autodiff and emit the forward result plus input gradients
+    Autodiff {
+        /// Tensors JSON file
+        tensors: String,
+
+        /// Topology JSON file
+        #[arg(short = 't', long)]
+        topology: Option<String>,
+
+        /// Parenthesized einsum expression with explicit contraction order
+        #[arg(long)]
+        expr: Option<String>,
+
+        /// Gradient seed for the einsum output, using the Result JSON schema
+        #[arg(long = "grad-output")]
+        grad_output: Option<String>,
+
+        /// Output file (default: stdout)
+        #[arg(short, long)]
+        output: Option<String>,
+
+        /// Pretty-print JSON (default: auto-detect TTY)
+        #[arg(long)]
+        pretty: Option<bool>,
+    },
 }
 
 fn main() {
@@ -142,6 +169,21 @@ fn main() {
             &tensors,
             topology.as_deref(),
             expr.as_deref(),
+            output.as_deref(),
+            pretty,
+        ),
+        Commands::Autodiff {
+            tensors,
+            topology,
+            expr,
+            grad_output,
+            output,
+            pretty,
+        } => autodiff::run(
+            &tensors,
+            topology.as_deref(),
+            expr.as_deref(),
+            grad_output.as_deref(),
             output.as_deref(),
             pretty,
         ),

--- a/omeinsum-cli/tests/cli.rs
+++ b/omeinsum-cli/tests/cli.rs
@@ -513,3 +513,247 @@ fn test_contract_unknown_label_in_topology_error() {
         .failure()
         .stderr(contains("unknown label index"));
 }
+
+#[test]
+fn test_autodiff_scalar_output_default_seed() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 2.0, 3.0, 4.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "autodiff",
+            "--expr",
+            "ii->",
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["dtype"], "f64");
+    assert_eq!(result["order"], "col_major");
+    assert_eq!(result["result"]["shape"], serde_json::json!([]));
+    let result_data: Vec<f64> = serde_json::from_value(result["result"]["data"].clone()).unwrap();
+    assert_eq!(result_data, vec![5.0]);
+
+    let gradients = result["gradients"].as_array().unwrap();
+    assert_eq!(gradients.len(), 1);
+    assert_eq!(gradients[0]["input_index"], 0);
+    assert_eq!(gradients[0]["shape"], serde_json::json!([2, 2]));
+    let grad_data: Vec<f64> = serde_json::from_value(gradients[0]["data"].clone()).unwrap();
+    assert_eq!(grad_data, vec![1.0, 0.0, 0.0, 1.0]);
+}
+
+#[test]
+fn test_autodiff_seeded_nonscalar_row_major() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "row_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 2.0, 3.0, 4.0]},
+            {"shape": [2, 2], "data": [5.0, 6.0, 7.0, 8.0]}
+        ]
+    }"#,
+    );
+    let grad_output = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "row_major",
+        "shape": [2, 2],
+        "data": [1.0, 1.0, 1.0, 1.0]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "autodiff",
+            "--expr",
+            "ij,jk->ik",
+            "--grad-output",
+            grad_output.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["dtype"], "f64");
+    assert_eq!(result["order"], "row_major");
+    assert_eq!(result["result"]["shape"], serde_json::json!([2, 2]));
+    let result_data: Vec<f64> = serde_json::from_value(result["result"]["data"].clone()).unwrap();
+    assert_eq!(result_data, vec![19.0, 22.0, 43.0, 50.0]);
+
+    let gradients = result["gradients"].as_array().unwrap();
+    assert_eq!(gradients.len(), 2);
+    assert_eq!(gradients[0]["input_index"], 0);
+    assert_eq!(gradients[1]["input_index"], 1);
+    let grad_a: Vec<f64> = serde_json::from_value(gradients[0]["data"].clone()).unwrap();
+    let grad_b: Vec<f64> = serde_json::from_value(gradients[1]["data"].clone()).unwrap();
+    assert_eq!(grad_a, vec![11.0, 15.0, 11.0, 15.0]);
+    assert_eq!(grad_b, vec![4.0, 4.0, 6.0, 6.0]);
+}
+
+#[test]
+fn test_autodiff_nonscalar_requires_grad_output() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 2.0, 3.0, 4.0]},
+            {"shape": [2, 2], "data": [5.0, 6.0, 7.0, 8.0]}
+        ]
+    }"#,
+    );
+
+    cmd()
+        .args([
+            "autodiff",
+            "--expr",
+            "ij,jk->ik",
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("Non-scalar output requires --grad-output"));
+}
+
+#[test]
+fn test_autodiff_grad_output_shape_mismatch() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 2.0, 3.0, 4.0]},
+            {"shape": [2, 2], "data": [5.0, 6.0, 7.0, 8.0]}
+        ]
+    }"#,
+    );
+    let grad_output = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "shape": [4],
+        "data": [1.0, 1.0, 1.0, 1.0]
+    }"#,
+    );
+
+    cmd()
+        .args([
+            "autodiff",
+            "--expr",
+            "ij,jk->ik",
+            "--grad-output",
+            grad_output.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("grad_output shape"));
+}
+
+#[test]
+fn test_autodiff_with_topology_scalar_output() {
+    let topo_file = NamedTempFile::new().unwrap();
+    let topo_path = topo_file.path().to_str().unwrap().to_string();
+
+    cmd()
+        .args(["optimize", "ii->", "--sizes", "i=2", "-o", &topo_path])
+        .assert()
+        .success();
+
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 2.0, 3.0, 4.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "autodiff",
+            "-t",
+            &topo_path,
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let result_data: Vec<f64> = serde_json::from_value(result["result"]["data"].clone()).unwrap();
+    assert_eq!(result_data, vec![5.0]);
+    let gradients = result["gradients"].as_array().unwrap();
+    let grad_data: Vec<f64> = serde_json::from_value(gradients[0]["data"].clone()).unwrap();
+    assert_eq!(grad_data, vec![1.0, 0.0, 0.0, 1.0]);
+}
+
+#[test]
+fn test_autodiff_grad_output_order_mismatch() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 2.0, 3.0, 4.0]},
+            {"shape": [2, 2], "data": [5.0, 6.0, 7.0, 8.0]}
+        ]
+    }"#,
+    );
+    let grad_output = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "row_major",
+        "shape": [2, 2],
+        "data": [1.0, 1.0, 1.0, 1.0]
+    }"#,
+    );
+
+    cmd()
+        .args([
+            "autodiff",
+            "--expr",
+            "ij,jk->ik",
+            "--grad-output",
+            grad_output.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("grad_output order"));
+}

--- a/omeinsum-cli/tests/cli.rs
+++ b/omeinsum-cli/tests/cli.rs
@@ -515,6 +515,39 @@ fn test_contract_unknown_label_in_topology_error() {
 }
 
 #[test]
+fn test_contract_missing_size_for_topology_expression_error() {
+    let topology = write_temp_json(
+        r#"{
+        "schema_version": 1,
+        "expression": "i->i",
+        "label_map": {"i": 0},
+        "size_dict": {},
+        "method": "greedy",
+        "tree": {"Leaf": {"tensor_index": 0}}
+    }"#,
+    );
+
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "f64",
+        "order": "col_major",
+        "tensors": [{"shape": [2], "data": [1.0, 2.0]}]
+    }"#,
+    );
+
+    cmd()
+        .args([
+            "contract",
+            "-t",
+            topology.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("Missing size for label index"));
+}
+
+#[test]
 fn test_autodiff_scalar_output_default_seed() {
     let tensors = write_temp_json(
         r#"{
@@ -557,6 +590,51 @@ fn test_autodiff_scalar_output_default_seed() {
     assert_eq!(gradients[0]["shape"], serde_json::json!([2, 2]));
     let grad_data: Vec<f64> = serde_json::from_value(gradients[0]["data"].clone()).unwrap();
     assert_eq!(grad_data, vec![1.0, 0.0, 0.0, 1.0]);
+}
+
+#[test]
+fn test_autodiff_complex_scalar_output_default_seed() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "c64",
+        "order": "col_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 2.0, -1.0]}
+        ]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "autodiff",
+            "--expr",
+            "ii->",
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["dtype"], "c64");
+    assert_eq!(result["order"], "col_major");
+    assert_eq!(result["result"]["shape"], serde_json::json!([]));
+    let result_data: Vec<f64> = serde_json::from_value(result["result"]["data"].clone()).unwrap();
+    assert_eq!(result_data, vec![3.0, 0.0]);
+
+    let gradients = result["gradients"].as_array().unwrap();
+    assert_eq!(gradients.len(), 1);
+    assert_eq!(gradients[0]["input_index"], 0);
+    assert_eq!(gradients[0]["shape"], serde_json::json!([2, 2]));
+    let grad_data: Vec<f64> = serde_json::from_value(gradients[0]["data"].clone()).unwrap();
+    assert_eq!(grad_data, vec![1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]);
 }
 
 #[test]
@@ -615,6 +693,61 @@ fn test_autodiff_seeded_nonscalar_row_major() {
     let grad_b: Vec<f64> = serde_json::from_value(gradients[1]["data"].clone()).unwrap();
     assert_eq!(grad_a, vec![11.0, 15.0, 11.0, 15.0]);
     assert_eq!(grad_b, vec![4.0, 4.0, 6.0, 6.0]);
+}
+
+#[test]
+fn test_autodiff_complex_seeded_nonscalar_row_major() {
+    let tensors = write_temp_json(
+        r#"{
+        "dtype": "c64",
+        "order": "row_major",
+        "tensors": [
+            {"shape": [2, 2], "data": [1.0, 1.0, 2.0, -1.0, 3.0, 0.0, 4.0, 2.0]}
+        ]
+    }"#,
+    );
+    let grad_output = write_temp_json(
+        r#"{
+        "dtype": "c64",
+        "order": "row_major",
+        "shape": [2, 2],
+        "data": [0.5, -1.0, 1.5, 0.0, -2.0, 0.25, 3.0, -4.0]
+    }"#,
+    );
+
+    let output = cmd()
+        .args([
+            "autodiff",
+            "--expr",
+            "ij->ij",
+            "--grad-output",
+            grad_output.path().to_str().unwrap(),
+            tensors.path().to_str().unwrap(),
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(result["dtype"], "c64");
+    assert_eq!(result["order"], "row_major");
+    assert_eq!(result["result"]["shape"], serde_json::json!([2, 2]));
+    let result_data: Vec<f64> = serde_json::from_value(result["result"]["data"].clone()).unwrap();
+    assert_eq!(result_data, vec![1.0, 1.0, 2.0, -1.0, 3.0, 0.0, 4.0, 2.0]);
+
+    let gradients = result["gradients"].as_array().unwrap();
+    assert_eq!(gradients.len(), 1);
+    assert_eq!(gradients[0]["input_index"], 0);
+    assert_eq!(gradients[0]["shape"], serde_json::json!([2, 2]));
+    let grad_data: Vec<f64> = serde_json::from_value(gradients[0]["data"].clone()).unwrap();
+    assert_eq!(grad_data, vec![0.5, -1.0, 1.5, 0.0, -2.0, 0.25, 3.0, -4.0]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an `omeinsum autodiff` CLI subcommand that emits the forward result plus indexed input gradients
- refactor shared CLI tensor/topology/result handling, add autodiff JSON schemas, and cover the new flows with integration tests and docs
- update the lockfile to `omeco 0.2.4`, which fixes the scalar-output optimizer regression test

## Test Plan
- [x] make check