### PR TITLE
perf: reduce contraction materialization overhead

### DIFF
--- a/src/backend/cpu/buffer_pool.rs
+++ b/src/backend/cpu/buffer_pool.rs
@@ -1,0 +1,78 @@
+#[derive(Default)]
+pub(crate) struct ScratchPool<T> {
+    free: Vec<Vec<T>>,
+}
+
+pub(crate) struct ScratchBuffer<'a, T> {
+    buf: Vec<T>,
+    pool: &'a mut ScratchPool<T>,
+}
+
+impl<T: Default> ScratchPool<T> {
+    pub(crate) fn acquire(&mut self, len: usize) -> ScratchBuffer<'_, T> {
+        let reuse_index = self
+            .free
+            .iter()
+            .enumerate()
+            .filter(|(_, buf)| buf.capacity() >= len)
+            .min_by_key(|(_, buf)| buf.capacity())
+            .map(|(index, _)| index);
+        let mut buf = reuse_index
+            .map(|index| self.free.swap_remove(index))
+            .unwrap_or_else(|| Vec::with_capacity(len));
+        buf.clear();
+        buf.resize_with(len, T::default);
+
+        ScratchBuffer { buf, pool: self }
+    }
+}
+
+impl<T> ScratchBuffer<'_, T> {
+    #[cfg(test)]
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [T] {
+        self.buf.as_mut_slice()
+    }
+
+    pub(crate) fn as_mut_vec(&mut self) -> &mut Vec<T> {
+        &mut self.buf
+    }
+
+    #[cfg(test)]
+    pub(crate) fn capacity(&self) -> usize {
+        self.buf.capacity()
+    }
+}
+
+impl<T> Drop for ScratchBuffer<'_, T> {
+    fn drop(&mut self) {
+        let mut buf = std::mem::take(&mut self.buf);
+        buf.clear();
+        self.pool.free.push(buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scratch_pool_reuses_released_capacity() {
+        let mut pool = ScratchPool::<f32>::default();
+        let mut first = pool.acquire(32);
+        first.as_mut_slice().fill(1.0);
+        drop(first);
+
+        let second = pool.acquire(16);
+        assert!(second.capacity() >= 32);
+    }
+
+    #[test]
+    fn test_scratch_pool_grows_when_requested_capacity_is_larger() {
+        let mut pool = ScratchPool::<f32>::default();
+        let small = pool.acquire(8);
+        drop(small);
+
+        let large = pool.acquire(128);
+        assert!(large.capacity() >= 128);
+    }
+}

--- a/src/backend/cpu/contract.rs
+++ b/src/backend/cpu/contract.rs
@@ -286,6 +286,7 @@ fn analyze_contraction_layout(
     }
 }
 
+use super::buffer_pool::ScratchPool;
 use super::MatrixLayout;
 use crate::algebra::Algebra;
 use crate::backend::Cpu;
@@ -391,7 +392,6 @@ fn materialize_matrix_operand<T: Copy + Default>(
     row_modes: &[i32],
     col_modes: &[i32],
 ) -> MaterializedMatrixOperand<T> {
-    let contiguous = ensure_contiguous(data, shape, strides);
     let perm = compute_permutation(modes, batch_modes, row_modes, col_modes);
     let target_modes: Vec<i32> = batch_modes
         .iter()
@@ -403,9 +403,12 @@ fn materialize_matrix_operand<T: Copy + Default>(
         .iter()
         .map(|&mode| shape[mode_position(modes, mode)])
         .collect();
+    let mut scratch = Vec::new();
 
     MaterializedMatrixOperand {
-        data: permute_data(&contiguous, shape, &perm),
+        data: materialize_with_permutation_into(data, shape, strides, &perm, &mut scratch)
+            .as_slice()
+            .to_vec(),
         strides: compute_contiguous_strides(&target_shape),
         shape: target_shape,
         modes: target_modes,
@@ -433,6 +436,19 @@ fn finalize_contraction_output<T: Copy + Default>(
         permute_data(&c_data, &c_shape_current, output_perm)
     } else {
         c_data
+    }
+}
+
+enum MaterializedSlice<'a, T> {
+    Borrowed(&'a [T]),
+    Scratch(&'a [T]),
+}
+
+impl<'a, T> MaterializedSlice<'a, T> {
+    fn as_slice(&self) -> &'a [T] {
+        match self {
+            Self::Borrowed(data) | Self::Scratch(data) => data,
+        }
     }
 }
 
@@ -549,30 +565,39 @@ where
         }
     }
 
-    // 3. Make inputs contiguous if needed for the generic materialized path.
-    let a_contig = ensure_contiguous(a, shape_a, strides_a);
-    let b_contig = ensure_contiguous(b, shape_b, strides_b);
+    let mut a_pool = ScratchPool::<A::Scalar>::default();
+    let mut b_pool = ScratchPool::<A::Scalar>::default();
 
-    // 4. Reduce trace modes before generic GEMM.
-    let (a_data, a_shape, a_modes) = if !left_trace.is_empty() {
-        reduce_trace_modes::<A>(&a_contig, shape_a, modes_a, &left_trace)
+    // 3. Reduce trace modes before the generic GEMM fallback.
+    let (a_reduced, a_shape, a_modes, a_strides) = if !left_trace.is_empty() {
+        let (a_data, a_shape, a_modes) = {
+            let mut a_contig = a_pool.acquire(shape_a.iter().product::<usize>().max(1));
+            let a_contig = ensure_contiguous_into(a, shape_a, strides_a, a_contig.as_mut_vec());
+            reduce_trace_modes::<A>(a_contig.as_slice(), shape_a, modes_a, &left_trace)
+        };
+        let a_strides = compute_contiguous_strides(&a_shape);
+        (Some(a_data), a_shape, a_modes, a_strides)
     } else {
-        (a_contig, shape_a.to_vec(), modes_a.to_vec())
+        (None, shape_a.to_vec(), modes_a.to_vec(), strides_a.to_vec())
     };
-    let (b_data, b_shape, b_modes) = if !right_trace.is_empty() {
-        reduce_trace_modes::<A>(&b_contig, shape_b, modes_b, &right_trace)
+    let (b_reduced, b_shape, b_modes, b_strides) = if !right_trace.is_empty() {
+        let (b_data, b_shape, b_modes) = {
+            let mut b_contig = b_pool.acquire(shape_b.iter().product::<usize>().max(1));
+            let b_contig = ensure_contiguous_into(b, shape_b, strides_b, b_contig.as_mut_vec());
+            reduce_trace_modes::<A>(b_contig.as_slice(), shape_b, modes_b, &right_trace)
+        };
+        let b_strides = compute_contiguous_strides(&b_shape);
+        (Some(b_data), b_shape, b_modes, b_strides)
     } else {
-        (b_contig, shape_b.to_vec(), modes_b.to_vec())
+        (None, shape_b.to_vec(), modes_b.to_vec(), strides_b.to_vec())
     };
 
-    let a_layout_strides = compute_contiguous_strides(&a_shape);
-    let b_layout_strides = compute_contiguous_strides(&b_shape);
     let plan = analyze_contraction_layout(
         &a_shape,
-        &a_layout_strides,
+        &a_strides,
         &a_modes,
         &b_shape,
-        &b_layout_strides,
+        &b_strides,
         &b_modes,
         modes_c,
     );
@@ -584,7 +609,12 @@ where
         &plan.contracted_modes,
         &plan.batch_modes,
     );
-    let a_permuted = permute_data(&a_data, &a_shape, &a_perm);
+    let mut a_permuted_scratch = a_pool.acquire(a_shape.iter().product::<usize>().max(1));
+    let a_permuted = if let Some(ref a_data) = a_reduced {
+        permute_data_into(a_data, &a_shape, &a_perm, a_permuted_scratch.as_mut_vec())
+    } else {
+        materialize_with_permutation_into(a, &a_shape, &a_strides, &a_perm, a_permuted_scratch.as_mut_vec())
+    };
 
     // 6. Permute B to [contracted, right_free, batch] - batch LAST
     let b_perm = compute_permutation(
@@ -593,24 +623,29 @@ where
         &plan.right_modes,
         &plan.batch_modes,
     );
-    let b_permuted = permute_data(&b_data, &b_shape, &b_perm);
+    let mut b_permuted_scratch = b_pool.acquire(b_shape.iter().product::<usize>().max(1));
+    let b_permuted = if let Some(ref b_data) = b_reduced {
+        permute_data_into(b_data, &b_shape, &b_perm, b_permuted_scratch.as_mut_vec())
+    } else {
+        materialize_with_permutation_into(b, &b_shape, &b_strides, &b_perm, b_permuted_scratch.as_mut_vec())
+    };
 
     // 7. Call GEMM
     let c_data = if plan.batch_modes.is_empty() {
         cpu.gemm_internal::<A>(
-            &a_permuted,
+            a_permuted.as_slice(),
             plan.left_size,
             plan.contract_size,
-            &b_permuted,
+            b_permuted.as_slice(),
             plan.right_size,
         )
     } else {
         cpu.gemm_batched_internal::<A>(
-            &a_permuted,
+            a_permuted.as_slice(),
             plan.batch_size,
             plan.left_size,
             plan.contract_size,
-            &b_permuted,
+            b_permuted.as_slice(),
             plan.right_size,
         )
     };
@@ -620,53 +655,58 @@ where
 
 /// Ensure data is contiguous (copy if strided).
 fn ensure_contiguous<T: Copy + Default>(data: &[T], shape: &[usize], strides: &[usize]) -> Vec<T> {
-    let expected_strides = compute_contiguous_strides(shape);
-    if strides == expected_strides {
-        data.to_vec()
-    } else {
-        // Copy with stride handling
-        let numel: usize = shape.iter().product();
-        let mut result = vec![T::default(); numel];
-        copy_strided_to_contiguous(data, &mut result, shape, strides);
-        result
-    }
+    let mut scratch = Vec::new();
+    ensure_contiguous_into(data, shape, strides, &mut scratch)
+        .as_slice()
+        .to_vec()
 }
 
-/// Copy strided data to contiguous buffer.
-fn copy_strided_to_contiguous<T: Copy>(
-    src: &[T],
-    dst: &mut [T],
+fn ensure_contiguous_into<'a, T: Copy + Default>(
+    data: &'a [T],
     shape: &[usize],
     strides: &[usize],
-) {
-    let numel: usize = shape.iter().product();
-
-    for (i, dst_elem) in dst.iter_mut().enumerate().take(numel) {
-        // Convert linear index to multi-index
-        let mut remaining = i;
-        let mut src_offset = 0;
-        for dim in 0..shape.len() {
-            let coord = remaining % shape[dim];
-            remaining /= shape[dim];
-            src_offset += coord * strides[dim];
-        }
-        *dst_elem = src[src_offset];
-    }
+    scratch: &'a mut Vec<T>,
+) -> MaterializedSlice<'a, T> {
+    let identity: Vec<usize> = (0..shape.len()).collect();
+    materialize_with_permutation_into(data, shape, strides, &identity, scratch)
 }
 
 /// Permute data according to axis permutation.
 fn permute_data<T: Copy + Default>(data: &[T], shape: &[usize], perm: &[usize]) -> Vec<T> {
-    if perm.iter().enumerate().all(|(i, &p)| i == p) {
-        return data.to_vec(); // Already in correct order
+    let mut scratch = Vec::new();
+    permute_data_into(data, shape, perm, &mut scratch)
+        .as_slice()
+        .to_vec()
+}
+
+fn permute_data_into<'a, T: Copy + Default>(
+    data: &'a [T],
+    shape: &[usize],
+    perm: &[usize],
+    scratch: &'a mut Vec<T>,
+) -> MaterializedSlice<'a, T> {
+    let strides = compute_contiguous_strides(shape);
+    materialize_with_permutation_into(data, shape, &strides, perm, scratch)
+}
+
+fn materialize_with_permutation_into<'a, T: Copy + Default>(
+    data: &'a [T],
+    shape: &[usize],
+    strides: &[usize],
+    perm: &[usize],
+    scratch: &'a mut Vec<T>,
+) -> MaterializedSlice<'a, T> {
+    let expected_strides = compute_contiguous_strides(shape);
+    if strides == expected_strides && perm.iter().enumerate().all(|(i, &p)| i == p) {
+        return MaterializedSlice::Borrowed(data);
     }
 
-    let new_shape: Vec<usize> = perm.iter().map(|&p| shape[p]).collect();
+    scratch.clear();
     let numel: usize = shape.iter().product();
-    let mut result = vec![T::default(); numel];
+    scratch.resize(numel, T::default());
+    let new_shape: Vec<usize> = perm.iter().map(|&p| shape[p]).collect();
 
-    let old_strides = compute_contiguous_strides(shape);
-
-    for (new_idx, result_elem) in result.iter_mut().enumerate().take(numel) {
+    for (new_idx, result_elem) in scratch.iter_mut().enumerate().take(numel) {
         // Convert new linear index to new multi-index
         let mut remaining = new_idx;
         let mut new_coords = vec![0; shape.len()];
@@ -678,13 +718,13 @@ fn permute_data<T: Copy + Default>(data: &[T], shape: &[usize], perm: &[usize]) 
         // Map to old coordinates via inverse permutation
         let mut old_idx = 0;
         for (new_dim, &old_dim) in perm.iter().enumerate() {
-            old_idx += new_coords[new_dim] * old_strides[old_dim];
+            old_idx += new_coords[new_dim] * strides[old_dim];
         }
 
         *result_elem = data[old_idx];
     }
 
-    result
+    MaterializedSlice::Scratch(scratch.as_slice())
 }
 
 /// Execute tensor contraction with argmax tracking.

--- a/src/backend/cpu/contract.rs
+++ b/src/backend/cpu/contract.rs
@@ -375,17 +375,41 @@ fn matrix_layout_from_operand<'a, T>(
     }
 }
 
+struct MaterializedMatrixOperand<T> {
+    data: Vec<T>,
+    shape: Vec<usize>,
+    strides: Vec<usize>,
+    modes: Vec<i32>,
+}
+
 fn materialize_matrix_operand<T: Copy + Default>(
     data: &[T],
     shape: &[usize],
     strides: &[usize],
     modes: &[i32],
+    batch_modes: &[i32],
     row_modes: &[i32],
     col_modes: &[i32],
-) -> Vec<T> {
+) -> MaterializedMatrixOperand<T> {
     let contiguous = ensure_contiguous(data, shape, strides);
-    let perm = compute_permutation(modes, row_modes, col_modes, &[]);
-    permute_data(&contiguous, shape, &perm)
+    let perm = compute_permutation(modes, batch_modes, row_modes, col_modes);
+    let target_modes: Vec<i32> = batch_modes
+        .iter()
+        .chain(row_modes.iter())
+        .chain(col_modes.iter())
+        .copied()
+        .collect();
+    let target_shape: Vec<usize> = target_modes
+        .iter()
+        .map(|&mode| shape[mode_position(modes, mode)])
+        .collect();
+
+    MaterializedMatrixOperand {
+        data: permute_data(&contiguous, shape, &perm),
+        strides: compute_contiguous_strides(&target_shape),
+        shape: target_shape,
+        modes: target_modes,
+    }
 }
 
 fn finalize_contraction_output<T: Copy + Default>(
@@ -451,65 +475,76 @@ where
     if left_trace.is_empty() && right_trace.is_empty() {
         let plan =
             analyze_contraction_layout(shape_a, strides_a, modes_a, shape_b, strides_b, modes_b, modes_c);
-        if plan.batch_modes.is_empty() {
-            let left_nocopy = matches!(plan.left_materialization, MaterializationPlan::NoCopy);
-            let right_nocopy = matches!(plan.right_materialization, MaterializationPlan::NoCopy);
-            if left_nocopy || right_nocopy {
-                let left_materialized;
-                let a_layout = if left_nocopy {
-                    matrix_layout_from_operand(
-                        a,
-                        shape_a,
-                        strides_a,
-                        modes_a,
-                        &plan.left_modes,
-                        &plan.contracted_modes,
-                    )
-                } else {
-                    left_materialized = materialize_matrix_operand(
-                        a,
-                        shape_a,
-                        strides_a,
-                        modes_a,
-                        &plan.left_modes,
-                        &plan.contracted_modes,
-                    );
-                    MatrixLayout::column_major(
-                        &left_materialized,
-                        plan.left_size,
-                        plan.contract_size,
-                    )
-                };
+        let left_nocopy = matches!(plan.left_materialization, MaterializationPlan::NoCopy);
+        let right_nocopy = matches!(plan.right_materialization, MaterializationPlan::NoCopy);
+        if left_nocopy || right_nocopy {
+            let left_materialized;
+            let a_layout = if left_nocopy {
+                matrix_layout_from_operand(
+                    a,
+                    shape_a,
+                    strides_a,
+                    modes_a,
+                    &plan.left_modes,
+                    &plan.contracted_modes,
+                )
+            } else {
+                left_materialized = materialize_matrix_operand(
+                    a,
+                    shape_a,
+                    strides_a,
+                    modes_a,
+                    &plan.batch_modes,
+                    &plan.left_modes,
+                    &plan.contracted_modes,
+                );
+                matrix_layout_from_operand(
+                    &left_materialized.data,
+                    &left_materialized.shape,
+                    &left_materialized.strides,
+                    &left_materialized.modes,
+                    &plan.left_modes,
+                    &plan.contracted_modes,
+                )
+            };
 
-                let right_materialized;
-                let b_layout = if right_nocopy {
-                    matrix_layout_from_operand(
-                        b,
-                        shape_b,
-                        strides_b,
-                        modes_b,
-                        &plan.contracted_modes,
-                        &plan.right_modes,
-                    )
-                } else {
-                    right_materialized = materialize_matrix_operand(
-                        b,
-                        shape_b,
-                        strides_b,
-                        modes_b,
-                        &plan.contracted_modes,
-                        &plan.right_modes,
-                    );
-                    MatrixLayout::column_major(
-                        &right_materialized,
-                        plan.contract_size,
-                        plan.right_size,
-                    )
-                };
+            let right_materialized;
+            let b_layout = if right_nocopy {
+                matrix_layout_from_operand(
+                    b,
+                    shape_b,
+                    strides_b,
+                    modes_b,
+                    &plan.contracted_modes,
+                    &plan.right_modes,
+                )
+            } else {
+                right_materialized = materialize_matrix_operand(
+                    b,
+                    shape_b,
+                    strides_b,
+                    modes_b,
+                    &plan.batch_modes,
+                    &plan.contracted_modes,
+                    &plan.right_modes,
+                );
+                matrix_layout_from_operand(
+                    &right_materialized.data,
+                    &right_materialized.shape,
+                    &right_materialized.strides,
+                    &right_materialized.modes,
+                    &plan.contracted_modes,
+                    &plan.right_modes,
+                )
+            };
 
-                if let Some(c_data) = cpu.gemm_standard_layout_internal::<A>(a_layout, b_layout) {
-                    return finalize_contraction_output(c_data, &plan, shape_c, modes_c);
-                }
+            let c_data = if plan.batch_modes.is_empty() {
+                cpu.gemm_standard_layout_internal::<A>(a_layout, b_layout)
+            } else {
+                cpu.gemm_batched_standard_layout_internal::<A>(plan.batch_size, a_layout, b_layout)
+            };
+            if let Some(c_data) = c_data {
+                return finalize_contraction_output(c_data, &plan, shape_c, modes_c);
             }
         }
     }
@@ -843,5 +878,23 @@ mod tests {
             plan.right_materialization,
             MaterializationPlan::Permute { .. }
         ));
+    }
+
+    #[test]
+    fn test_analyze_contraction_layout_preserves_batch_tail() {
+        let plan = analyze_contraction_layout(
+            &[2, 2, 2],
+            &[1, 2, 4],
+            &[0, 1, 2],
+            &[2, 2, 2],
+            &[1, 2, 4],
+            &[0, 2, 3],
+            &[0, 1, 3],
+        );
+
+        assert_eq!(plan.batch_modes, vec![0]);
+        assert_eq!(plan.batch_size, 2);
+        assert!(matches!(plan.left_materialization, MaterializationPlan::NoCopy));
+        assert!(matches!(plan.right_materialization, MaterializationPlan::NoCopy));
     }
 }

--- a/src/backend/cpu/contract.rs
+++ b/src/backend/cpu/contract.rs
@@ -78,6 +78,214 @@ pub(super) fn compute_permutation(
     target.iter().map(|m| mode_position(current, *m)).collect()
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MaterializationPlan {
+    NoCopy,
+    MakeContiguous,
+    Permute { perm: Vec<usize>, shape: Vec<usize> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ContractionLayoutPlan {
+    batch_modes: Vec<i32>,
+    left_modes: Vec<i32>,
+    right_modes: Vec<i32>,
+    contracted_modes: Vec<i32>,
+    left_materialization: MaterializationPlan,
+    right_materialization: MaterializationPlan,
+    output_perm: Option<Vec<usize>>,
+    batch_size: usize,
+    left_size: usize,
+    right_size: usize,
+    contract_size: usize,
+}
+
+fn physical_axis_order(strides: &[usize]) -> Vec<usize> {
+    let mut axes: Vec<usize> = (0..strides.len()).collect();
+    axes.sort_by_key(|&axis| (strides[axis], axis));
+    axes
+}
+
+fn is_flattenable_group(
+    shape: &[usize],
+    strides: &[usize],
+    axes: &[usize],
+    require_unit_base: bool,
+) -> bool {
+    if axes.is_empty() {
+        return true;
+    }
+
+    let mut expected = if require_unit_base { 1 } else { strides[axes[0]] };
+    if require_unit_base && strides[axes[0]] != 1 {
+        return false;
+    }
+
+    for &axis in axes {
+        if strides[axis] != expected {
+            return false;
+        }
+        expected = expected.saturating_mul(shape[axis].max(1));
+    }
+
+    true
+}
+
+fn is_permutation_like(shape: &[usize], strides: &[usize], physical_order: &[usize]) -> bool {
+    let mut expected = 1usize;
+    for &axis in physical_order {
+        if strides[axis] != expected {
+            return false;
+        }
+        expected = expected.saturating_mul(shape[axis].max(1));
+    }
+    true
+}
+
+fn analyze_operand_materialization(
+    shape: &[usize],
+    strides: &[usize],
+    modes: &[i32],
+    batch_modes: &[i32],
+    row_modes: &[i32],
+    col_modes: &[i32],
+) -> MaterializationPlan {
+    let batch_axes: Vec<usize> = batch_modes
+        .iter()
+        .map(|&mode| mode_position(modes, mode))
+        .collect();
+    let row_axes: Vec<usize> = row_modes.iter().map(|&mode| mode_position(modes, mode)).collect();
+    let col_axes: Vec<usize> = col_modes.iter().map(|&mode| mode_position(modes, mode)).collect();
+    let physical_order = physical_axis_order(strides);
+
+    let mut no_copy_orders = vec![batch_axes
+        .iter()
+        .chain(row_axes.iter())
+        .chain(col_axes.iter())
+        .copied()
+        .collect::<Vec<_>>()];
+    if row_axes != col_axes {
+        no_copy_orders.push(
+            batch_axes
+                .iter()
+                .chain(col_axes.iter())
+                .chain(row_axes.iter())
+                .copied()
+                .collect(),
+        );
+    }
+
+    let batch_len = batch_axes.len();
+    let row_len = row_axes.len();
+    for order in &no_copy_orders {
+        let rows = &order[batch_len..batch_len + row_len];
+        let cols = &order[batch_len + row_len..];
+        if *order == physical_order
+            && is_flattenable_group(shape, strides, &batch_axes, !batch_axes.is_empty())
+            && is_flattenable_group(shape, strides, rows, false)
+            && is_flattenable_group(shape, strides, cols, false)
+        {
+            return MaterializationPlan::NoCopy;
+        }
+    }
+
+    if is_permutation_like(shape, strides, &physical_order) {
+        let target_axes: Vec<usize> = batch_axes
+            .iter()
+            .chain(row_axes.iter())
+            .chain(col_axes.iter())
+            .copied()
+            .collect();
+        let perm: Vec<usize> = target_axes
+            .iter()
+            .map(|axis| {
+                physical_order
+                    .iter()
+                    .position(|physical_axis| physical_axis == axis)
+                    .expect("axis must exist in physical order")
+            })
+            .collect();
+        let physical_shape: Vec<usize> = physical_order.iter().map(|&axis| shape[axis]).collect();
+        return MaterializationPlan::Permute {
+            perm,
+            shape: physical_shape,
+        };
+    }
+
+    MaterializationPlan::MakeContiguous
+}
+
+fn analyze_contraction_layout(
+    shape_a: &[usize],
+    strides_a: &[usize],
+    modes_a: &[i32],
+    shape_b: &[usize],
+    strides_b: &[usize],
+    modes_b: &[i32],
+    modes_c: &[i32],
+) -> ContractionLayoutPlan {
+    let (batch_modes, left_candidates, right_candidates, contracted_modes) =
+        classify_modes(modes_a, modes_b, modes_c);
+    let output_set: HashSet<i32> = modes_c.iter().copied().collect();
+    let left_modes: Vec<i32> = left_candidates
+        .into_iter()
+        .filter(|mode| output_set.contains(mode))
+        .collect();
+    let right_modes: Vec<i32> = right_candidates
+        .into_iter()
+        .filter(|mode| output_set.contains(mode))
+        .collect();
+
+    let left_materialization = analyze_operand_materialization(
+        shape_a,
+        strides_a,
+        modes_a,
+        &batch_modes,
+        &left_modes,
+        &contracted_modes,
+    );
+    let right_materialization = analyze_operand_materialization(
+        shape_b,
+        strides_b,
+        modes_b,
+        &batch_modes,
+        &contracted_modes,
+        &right_modes,
+    );
+
+    let current_output: Vec<i32> = left_modes
+        .iter()
+        .chain(right_modes.iter())
+        .chain(batch_modes.iter())
+        .copied()
+        .collect();
+    let output_perm = (current_output != modes_c).then(|| {
+        modes_c
+            .iter()
+            .map(|mode| {
+                current_output
+                    .iter()
+                    .position(|current_mode| current_mode == mode)
+                    .expect("output mode must exist in current output")
+            })
+            .collect()
+    });
+
+    ContractionLayoutPlan {
+        batch_size: product_of_dims(&batch_modes, modes_a, shape_a),
+        left_size: product_of_dims(&left_modes, modes_a, shape_a),
+        right_size: product_of_dims(&right_modes, modes_b, shape_b),
+        contract_size: product_of_dims(&contracted_modes, modes_a, shape_a),
+        batch_modes,
+        left_modes,
+        right_modes,
+        contracted_modes,
+        left_materialization,
+        right_materialization,
+        output_perm,
+    }
+}
+
 use crate::algebra::Algebra;
 use crate::backend::Cpu;
 use crate::tensor::compute_contiguous_strides;
@@ -165,7 +373,7 @@ where
     let b_contig = ensure_contiguous(b, shape_b, strides_b);
 
     // 2. Classify modes
-    let (batch, left, right, contracted) = classify_modes(modes_a, modes_b, modes_c);
+    let (_batch, left, right, _contracted) = classify_modes(modes_a, modes_b, modes_c);
 
     // 3. Handle trace modes: modes in only one input that are NOT in the output.
     //    GEMM can only contract modes shared by both inputs. Single-input modes
@@ -193,69 +401,80 @@ where
         (b_contig, shape_b.to_vec(), modes_b.to_vec())
     };
 
-    // Free modes (left/right modes that ARE in the output)
-    let left_free: Vec<i32> = left.iter().filter(|m| c_set.contains(m)).copied().collect();
-    let right_free: Vec<i32> = right
-        .iter()
-        .filter(|m| c_set.contains(m))
-        .copied()
-        .collect();
+    let a_layout_strides = compute_contiguous_strides(&a_shape);
+    let b_layout_strides = compute_contiguous_strides(&b_shape);
+    let plan = analyze_contraction_layout(
+        &a_shape,
+        &a_layout_strides,
+        &a_modes,
+        &b_shape,
+        &b_layout_strides,
+        &b_modes,
+        modes_c,
+    );
 
-    // 4. Compute dimension sizes (using reduced inputs)
-    let batch_size = product_of_dims(&batch, &a_modes, &a_shape);
-    let left_size = product_of_dims(&left_free, &a_modes, &a_shape);
-    let right_size = product_of_dims(&right_free, &b_modes, &b_shape);
-    let contract_size = product_of_dims(&contracted, &a_modes, &a_shape);
-
-    // 5. Permute A to [left_free, contracted, batch] - batch LAST for correct memory layout
-    let a_perm = compute_permutation(&a_modes, &left_free, &contracted, &batch);
+    // 4. Permute A to [left_free, contracted, batch] - batch LAST for current GEMM layout
+    let a_perm = compute_permutation(
+        &a_modes,
+        &plan.left_modes,
+        &plan.contracted_modes,
+        &plan.batch_modes,
+    );
     let a_permuted = permute_data(&a_data, &a_shape, &a_perm);
 
-    // 6. Permute B to [contracted, right_free, batch] - batch LAST
-    let b_perm = compute_permutation(&b_modes, &contracted, &right_free, &batch);
+    // 5. Permute B to [contracted, right_free, batch] - batch LAST
+    let b_perm = compute_permutation(
+        &b_modes,
+        &plan.contracted_modes,
+        &plan.right_modes,
+        &plan.batch_modes,
+    );
     let b_permuted = permute_data(&b_data, &b_shape, &b_perm);
 
-    // 7. Call GEMM
-    let c_data = if batch.is_empty() {
+    // 6. Call GEMM
+    let c_data = if plan.batch_modes.is_empty() {
         cpu.gemm_internal::<A>(
             &a_permuted,
-            left_size,
-            contract_size,
+            plan.left_size,
+            plan.contract_size,
             &b_permuted,
-            right_size,
+            plan.right_size,
         )
     } else {
         cpu.gemm_batched_internal::<A>(
             &a_permuted,
-            batch_size,
-            left_size,
-            contract_size,
+            plan.batch_size,
+            plan.left_size,
+            plan.contract_size,
             &b_permuted,
-            right_size,
+            plan.right_size,
         )
     };
 
-    // 8. Permute result to output order
+    // 7. Permute result to output order
     // Result is in [left_free, right_free, batch] order
-    let current_order: Vec<i32> = left_free
+    let current_order: Vec<i32> = plan
+        .left_modes
         .iter()
-        .chain(right_free.iter())
-        .chain(batch.iter())
+        .chain(plan.right_modes.iter())
+        .chain(plan.batch_modes.iter())
         .copied()
         .collect();
 
-    if current_order == modes_c {
+    if plan.output_perm.is_none() {
         c_data
     } else {
         let c_shape_current: Vec<usize> = current_order
             .iter()
             .map(|&m| shape_c[mode_position(modes_c, m)])
             .collect();
-        let out_perm: Vec<usize> = modes_c
-            .iter()
-            .map(|m| current_order.iter().position(|x| x == m).unwrap())
-            .collect();
-        permute_data(&c_data, &c_shape_current, &out_perm)
+        permute_data(
+            &c_data,
+            &c_shape_current,
+            plan.output_perm
+                .as_ref()
+                .expect("output permutation must exist"),
+        )
     }
 }
 
@@ -480,5 +699,44 @@ mod tests {
         // Current: [0, 1, 2], want: [0, 2, 1]
         let perm = compute_permutation(&[0, 1, 2], &[0], &[2], &[1]);
         assert_eq!(perm, vec![0, 2, 1]);
+    }
+
+    #[test]
+    fn test_analyze_contraction_layout_detects_copy_free_matmul() {
+        let plan = analyze_contraction_layout(
+            &[2, 3],
+            &[1, 2],
+            &[0, 1],
+            &[3, 4],
+            &[1, 3],
+            &[1, 2],
+            &[0, 2],
+        );
+
+        assert!(plan.batch_modes.is_empty());
+        assert_eq!(plan.left_modes, vec![0]);
+        assert_eq!(plan.right_modes, vec![2]);
+        assert_eq!(plan.contracted_modes, vec![1]);
+        assert!(matches!(plan.left_materialization, MaterializationPlan::NoCopy));
+        assert!(matches!(plan.right_materialization, MaterializationPlan::NoCopy));
+    }
+
+    #[test]
+    fn test_analyze_contraction_layout_marks_single_side_materialization() {
+        let plan = analyze_contraction_layout(
+            &[2, 2, 2],
+            &[1, 2, 4],
+            &[0, 1, 2],
+            &[2, 2, 2],
+            &[2, 1, 4],
+            &[0, 2, 3],
+            &[0, 1, 3],
+        );
+
+        assert!(matches!(plan.left_materialization, MaterializationPlan::NoCopy));
+        assert!(matches!(
+            plan.right_materialization,
+            MaterializationPlan::Permute { .. }
+        ));
     }
 }

--- a/src/backend/cpu/contract.rs
+++ b/src/backend/cpu/contract.rs
@@ -286,6 +286,7 @@ fn analyze_contraction_layout(
     }
 }
 
+use super::MatrixLayout;
 use crate::algebra::Algebra;
 use crate::backend::Cpu;
 use crate::tensor::compute_contiguous_strides;
@@ -350,6 +351,67 @@ where
     (result, new_shape, new_modes)
 }
 
+fn group_base_stride(modes: &[i32], strides: &[usize], group_modes: &[i32]) -> isize {
+    group_modes
+        .first()
+        .map(|&mode| strides[mode_position(modes, mode)] as isize)
+        .unwrap_or(0)
+}
+
+fn matrix_layout_from_operand<'a, T>(
+    data: &'a [T],
+    shape: &[usize],
+    strides: &[usize],
+    modes: &[i32],
+    row_modes: &[i32],
+    col_modes: &[i32],
+) -> MatrixLayout<'a, T> {
+    MatrixLayout {
+        data,
+        rows: product_of_dims(row_modes, modes, shape),
+        cols: product_of_dims(col_modes, modes, shape),
+        row_stride: group_base_stride(modes, strides, row_modes),
+        col_stride: group_base_stride(modes, strides, col_modes),
+    }
+}
+
+fn materialize_matrix_operand<T: Copy + Default>(
+    data: &[T],
+    shape: &[usize],
+    strides: &[usize],
+    modes: &[i32],
+    row_modes: &[i32],
+    col_modes: &[i32],
+) -> Vec<T> {
+    let contiguous = ensure_contiguous(data, shape, strides);
+    let perm = compute_permutation(modes, row_modes, col_modes, &[]);
+    permute_data(&contiguous, shape, &perm)
+}
+
+fn finalize_contraction_output<T: Copy + Default>(
+    c_data: Vec<T>,
+    plan: &ContractionLayoutPlan,
+    shape_c: &[usize],
+    modes_c: &[i32],
+) -> Vec<T> {
+    if let Some(output_perm) = &plan.output_perm {
+        let current_order: Vec<i32> = plan
+            .left_modes
+            .iter()
+            .chain(plan.right_modes.iter())
+            .chain(plan.batch_modes.iter())
+            .copied()
+            .collect();
+        let c_shape_current: Vec<usize> = current_order
+            .iter()
+            .map(|&mode| shape_c[mode_position(modes_c, mode)])
+            .collect();
+        permute_data(&c_data, &c_shape_current, output_perm)
+    } else {
+        c_data
+    }
+}
+
 /// Execute tensor contraction on CPU via reshape→GEMM→reshape.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn contract<A: Algebra>(
@@ -368,14 +430,10 @@ pub(super) fn contract<A: Algebra>(
 where
     A::Scalar: crate::algebra::Scalar,
 {
-    // 1. Make inputs contiguous if needed
-    let a_contig = ensure_contiguous(a, shape_a, strides_a);
-    let b_contig = ensure_contiguous(b, shape_b, strides_b);
-
-    // 2. Classify modes
+    // 1. Classify modes
     let (_batch, left, right, _contracted) = classify_modes(modes_a, modes_b, modes_c);
 
-    // 3. Handle trace modes: modes in only one input that are NOT in the output.
+    // 2. Handle trace modes: modes in only one input that are NOT in the output.
     //    GEMM can only contract modes shared by both inputs. Single-input modes
     //    not in the output must be summed over (traced) before GEMM.
     let c_set: HashSet<i32> = modes_c.iter().copied().collect();
@@ -390,6 +448,77 @@ where
         .copied()
         .collect();
 
+    if left_trace.is_empty() && right_trace.is_empty() {
+        let plan =
+            analyze_contraction_layout(shape_a, strides_a, modes_a, shape_b, strides_b, modes_b, modes_c);
+        if plan.batch_modes.is_empty() {
+            let left_nocopy = matches!(plan.left_materialization, MaterializationPlan::NoCopy);
+            let right_nocopy = matches!(plan.right_materialization, MaterializationPlan::NoCopy);
+            if left_nocopy || right_nocopy {
+                let left_materialized;
+                let a_layout = if left_nocopy {
+                    matrix_layout_from_operand(
+                        a,
+                        shape_a,
+                        strides_a,
+                        modes_a,
+                        &plan.left_modes,
+                        &plan.contracted_modes,
+                    )
+                } else {
+                    left_materialized = materialize_matrix_operand(
+                        a,
+                        shape_a,
+                        strides_a,
+                        modes_a,
+                        &plan.left_modes,
+                        &plan.contracted_modes,
+                    );
+                    MatrixLayout::column_major(
+                        &left_materialized,
+                        plan.left_size,
+                        plan.contract_size,
+                    )
+                };
+
+                let right_materialized;
+                let b_layout = if right_nocopy {
+                    matrix_layout_from_operand(
+                        b,
+                        shape_b,
+                        strides_b,
+                        modes_b,
+                        &plan.contracted_modes,
+                        &plan.right_modes,
+                    )
+                } else {
+                    right_materialized = materialize_matrix_operand(
+                        b,
+                        shape_b,
+                        strides_b,
+                        modes_b,
+                        &plan.contracted_modes,
+                        &plan.right_modes,
+                    );
+                    MatrixLayout::column_major(
+                        &right_materialized,
+                        plan.contract_size,
+                        plan.right_size,
+                    )
+                };
+
+                if let Some(c_data) = cpu.gemm_standard_layout_internal::<A>(a_layout, b_layout) {
+                    return finalize_contraction_output(c_data, &plan, shape_c, modes_c);
+                }
+            }
+        }
+    }
+
+    // 3. Make inputs contiguous if needed for the generic materialized path.
+    let a_contig = ensure_contiguous(a, shape_a, strides_a);
+    let b_contig = ensure_contiguous(b, shape_b, strides_b);
+
+    // 4. Reduce trace modes before generic GEMM.
     let (a_data, a_shape, a_modes) = if !left_trace.is_empty() {
         reduce_trace_modes::<A>(&a_contig, shape_a, modes_a, &left_trace)
     } else {
@@ -413,7 +542,7 @@ where
         modes_c,
     );
 
-    // 4. Permute A to [left_free, contracted, batch] - batch LAST for current GEMM layout
+    // 5. Permute A to [left_free, contracted, batch] - batch LAST for current GEMM layout
     let a_perm = compute_permutation(
         &a_modes,
         &plan.left_modes,
@@ -422,7 +551,7 @@ where
     );
     let a_permuted = permute_data(&a_data, &a_shape, &a_perm);
 
-    // 5. Permute B to [contracted, right_free, batch] - batch LAST
+    // 6. Permute B to [contracted, right_free, batch] - batch LAST
     let b_perm = compute_permutation(
         &b_modes,
         &plan.contracted_modes,
@@ -431,7 +560,7 @@ where
     );
     let b_permuted = permute_data(&b_data, &b_shape, &b_perm);
 
-    // 6. Call GEMM
+    // 7. Call GEMM
     let c_data = if plan.batch_modes.is_empty() {
         cpu.gemm_internal::<A>(
             &a_permuted,
@@ -451,31 +580,7 @@ where
         )
     };
 
-    // 7. Permute result to output order
-    // Result is in [left_free, right_free, batch] order
-    let current_order: Vec<i32> = plan
-        .left_modes
-        .iter()
-        .chain(plan.right_modes.iter())
-        .chain(plan.batch_modes.iter())
-        .copied()
-        .collect();
-
-    if plan.output_perm.is_none() {
-        c_data
-    } else {
-        let c_shape_current: Vec<usize> = current_order
-            .iter()
-            .map(|&m| shape_c[mode_position(modes_c, m)])
-            .collect();
-        permute_data(
-            &c_data,
-            &c_shape_current,
-            plan.output_perm
-                .as_ref()
-                .expect("output permutation must exist"),
-        )
-    }
+    finalize_contraction_output(c_data, &plan, shape_c, modes_c)
 }
 
 /// Ensure data is contiguous (copy if strided).

--- a/src/backend/cpu/contract.rs
+++ b/src/backend/cpu/contract.rs
@@ -116,7 +116,11 @@ fn is_flattenable_group(
         return true;
     }
 
-    let mut expected = if require_unit_base { 1 } else { strides[axes[0]] };
+    let mut expected = if require_unit_base {
+        1
+    } else {
+        strides[axes[0]]
+    };
     if require_unit_base && strides[axes[0]] != 1 {
         return false;
     }
@@ -154,8 +158,14 @@ fn analyze_operand_materialization(
         .iter()
         .map(|&mode| mode_position(modes, mode))
         .collect();
-    let row_axes: Vec<usize> = row_modes.iter().map(|&mode| mode_position(modes, mode)).collect();
-    let col_axes: Vec<usize> = col_modes.iter().map(|&mode| mode_position(modes, mode)).collect();
+    let row_axes: Vec<usize> = row_modes
+        .iter()
+        .map(|&mode| mode_position(modes, mode))
+        .collect();
+    let col_axes: Vec<usize> = col_modes
+        .iter()
+        .map(|&mode| mode_position(modes, mode))
+        .collect();
     let physical_order = physical_axis_order(strides);
 
     let mut no_copy_orders = vec![batch_axes
@@ -489,8 +499,9 @@ where
         .collect();
 
     if left_trace.is_empty() && right_trace.is_empty() {
-        let plan =
-            analyze_contraction_layout(shape_a, strides_a, modes_a, shape_b, strides_b, modes_b, modes_c);
+        let plan = analyze_contraction_layout(
+            shape_a, strides_a, modes_a, shape_b, strides_b, modes_b, modes_c,
+        );
         let left_nocopy = matches!(plan.left_materialization, MaterializationPlan::NoCopy);
         let right_nocopy = matches!(plan.right_materialization, MaterializationPlan::NoCopy);
         if left_nocopy || right_nocopy {
@@ -593,13 +604,7 @@ where
     };
 
     let plan = analyze_contraction_layout(
-        &a_shape,
-        &a_strides,
-        &a_modes,
-        &b_shape,
-        &b_strides,
-        &b_modes,
-        modes_c,
+        &a_shape, &a_strides, &a_modes, &b_shape, &b_strides, &b_modes, modes_c,
     );
 
     // 5. Permute A to [left_free, contracted, batch] - batch LAST for current GEMM layout
@@ -613,7 +618,13 @@ where
     let a_permuted = if let Some(ref a_data) = a_reduced {
         permute_data_into(a_data, &a_shape, &a_perm, a_permuted_scratch.as_mut_vec())
     } else {
-        materialize_with_permutation_into(a, &a_shape, &a_strides, &a_perm, a_permuted_scratch.as_mut_vec())
+        materialize_with_permutation_into(
+            a,
+            &a_shape,
+            &a_strides,
+            &a_perm,
+            a_permuted_scratch.as_mut_vec(),
+        )
     };
 
     // 6. Permute B to [contracted, right_free, batch] - batch LAST
@@ -627,7 +638,13 @@ where
     let b_permuted = if let Some(ref b_data) = b_reduced {
         permute_data_into(b_data, &b_shape, &b_perm, b_permuted_scratch.as_mut_vec())
     } else {
-        materialize_with_permutation_into(b, &b_shape, &b_strides, &b_perm, b_permuted_scratch.as_mut_vec())
+        materialize_with_permutation_into(
+            b,
+            &b_shape,
+            &b_strides,
+            &b_perm,
+            b_permuted_scratch.as_mut_vec(),
+        )
     };
 
     // 7. Call GEMM
@@ -897,8 +914,14 @@ mod tests {
         assert_eq!(plan.left_modes, vec![0]);
         assert_eq!(plan.right_modes, vec![2]);
         assert_eq!(plan.contracted_modes, vec![1]);
-        assert!(matches!(plan.left_materialization, MaterializationPlan::NoCopy));
-        assert!(matches!(plan.right_materialization, MaterializationPlan::NoCopy));
+        assert!(matches!(
+            plan.left_materialization,
+            MaterializationPlan::NoCopy
+        ));
+        assert!(matches!(
+            plan.right_materialization,
+            MaterializationPlan::NoCopy
+        ));
     }
 
     #[test]
@@ -913,7 +936,10 @@ mod tests {
             &[0, 1, 3],
         );
 
-        assert!(matches!(plan.left_materialization, MaterializationPlan::NoCopy));
+        assert!(matches!(
+            plan.left_materialization,
+            MaterializationPlan::NoCopy
+        ));
         assert!(matches!(
             plan.right_materialization,
             MaterializationPlan::Permute { .. }
@@ -934,7 +960,13 @@ mod tests {
 
         assert_eq!(plan.batch_modes, vec![0]);
         assert_eq!(plan.batch_size, 2);
-        assert!(matches!(plan.left_materialization, MaterializationPlan::NoCopy));
-        assert!(matches!(plan.right_materialization, MaterializationPlan::NoCopy));
+        assert!(matches!(
+            plan.left_materialization,
+            MaterializationPlan::NoCopy
+        ));
+        assert!(matches!(
+            plan.right_materialization,
+            MaterializationPlan::NoCopy
+        ));
     }
 }

--- a/src/backend/cpu/mod.rs
+++ b/src/backend/cpu/mod.rs
@@ -20,6 +20,7 @@ pub(crate) struct MatrixLayout<'a, T> {
 }
 
 impl<'a, T> MatrixLayout<'a, T> {
+    #[cfg(test)]
     pub(crate) fn column_major(data: &'a [T], rows: usize, cols: usize) -> Self {
         Self {
             data,
@@ -86,6 +87,14 @@ fn faer_mat_ref<'a, T>(layout: MatrixLayout<'a, T>) -> faer::MatRef<'a, T> {
     }
 }
 
+fn matrix_layout_batch_view<'a, T>(layout: MatrixLayout<'a, T>, batch: usize) -> MatrixLayout<'a, T> {
+    assert!(batch < layout.data.len(), "batch offset must be in bounds");
+    MatrixLayout {
+        data: &layout.data[batch..],
+        ..layout
+    }
+}
+
 impl Cpu {
     pub(crate) fn gemm_standard_layout_internal<A: Algebra>(
         &self,
@@ -126,6 +135,74 @@ impl Cpu {
                 col_stride: b.col_stride,
             };
             let result = faer_gemm_f64_layout(a_f64, b_f64);
+            return Some(unsafe { std::mem::transmute::<Vec<f64>, Vec<A::Scalar>>(result) });
+        }
+
+        None
+    }
+
+    pub(crate) fn gemm_batched_standard_layout_internal<A: Algebra>(
+        &self,
+        batch_size: usize,
+        a: MatrixLayout<'_, A::Scalar>,
+        b: MatrixLayout<'_, A::Scalar>,
+    ) -> Option<Vec<A::Scalar>> {
+        let c_batch_stride = a.rows * b.cols;
+
+        if TypeId::of::<A>() == TypeId::of::<Standard<f32>>() {
+            let a_f32 = MatrixLayout {
+                data: unsafe { std::mem::transmute::<&[A::Scalar], &[f32]>(a.data) },
+                rows: a.rows,
+                cols: a.cols,
+                row_stride: a.row_stride,
+                col_stride: a.col_stride,
+            };
+            let b_f32 = MatrixLayout {
+                data: unsafe { std::mem::transmute::<&[A::Scalar], &[f32]>(b.data) },
+                rows: b.rows,
+                cols: b.cols,
+                row_stride: b.row_stride,
+                col_stride: b.col_stride,
+            };
+            let mut result = vec![0.0f32; batch_size * c_batch_stride];
+
+            for batch in 0..batch_size {
+                let c_offset = batch * c_batch_stride;
+                let c_batch = faer_gemm_f32_layout(
+                    matrix_layout_batch_view(a_f32, batch),
+                    matrix_layout_batch_view(b_f32, batch),
+                );
+                result[c_offset..c_offset + c_batch_stride].copy_from_slice(&c_batch);
+            }
+
+            return Some(unsafe { std::mem::transmute::<Vec<f32>, Vec<A::Scalar>>(result) });
+        }
+        if TypeId::of::<A>() == TypeId::of::<Standard<f64>>() {
+            let a_f64 = MatrixLayout {
+                data: unsafe { std::mem::transmute::<&[A::Scalar], &[f64]>(a.data) },
+                rows: a.rows,
+                cols: a.cols,
+                row_stride: a.row_stride,
+                col_stride: a.col_stride,
+            };
+            let b_f64 = MatrixLayout {
+                data: unsafe { std::mem::transmute::<&[A::Scalar], &[f64]>(b.data) },
+                rows: b.rows,
+                cols: b.cols,
+                row_stride: b.row_stride,
+                col_stride: b.col_stride,
+            };
+            let mut result = vec![0.0f64; batch_size * c_batch_stride];
+
+            for batch in 0..batch_size {
+                let c_offset = batch * c_batch_stride;
+                let c_batch = faer_gemm_f64_layout(
+                    matrix_layout_batch_view(a_f64, batch),
+                    matrix_layout_batch_view(b_f64, batch),
+                );
+                result[c_offset..c_offset + c_batch_stride].copy_from_slice(&c_batch);
+            }
+
             return Some(unsafe { std::mem::transmute::<Vec<f64>, Vec<A::Scalar>>(result) });
         }
 
@@ -829,6 +906,35 @@ mod tests {
 
         let expected = faer_gemm_f32(&a, 2, 2, &[1.0, 3.0, 2.0, 4.0], 2);
         assert_eq!(c, expected);
+    }
+
+    #[test]
+    fn test_gemm_batched_standard_layout_internal_accepts_batch_major_views() {
+        let cpu = Cpu;
+        let a = vec![1.0f32, 5.0, 2.0, 6.0, 3.0, 7.0, 4.0, 8.0];
+        let b = vec![1.0f32, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0];
+
+        let c = cpu
+            .gemm_batched_standard_layout_internal::<Standard<f32>>(
+                2,
+                MatrixLayout {
+                    data: &a,
+                    rows: 2,
+                    cols: 2,
+                    row_stride: 2,
+                    col_stride: 4,
+                },
+                MatrixLayout {
+                    data: &b,
+                    rows: 2,
+                    cols: 2,
+                    row_stride: 2,
+                    col_stride: 4,
+                },
+            )
+            .expect("standard layout helper should handle batch-major inputs");
+
+        assert_eq!(c, vec![1.0, 2.0, 3.0, 4.0, 10.0, 12.0, 14.0, 16.0]);
     }
 
     #[cfg(feature = "tropical")]

--- a/src/backend/cpu/mod.rs
+++ b/src/backend/cpu/mod.rs
@@ -1,5 +1,6 @@
 //! CPU backend implementation.
 
+mod buffer_pool;
 mod contract;
 
 use super::traits::{Backend, BackendScalar, Storage};

--- a/src/backend/cpu/mod.rs
+++ b/src/backend/cpu/mod.rs
@@ -65,7 +65,10 @@ fn layout_offset_bounds<T>(layout: &MatrixLayout<'_, T>) -> (isize, isize) {
 fn faer_mat_ref<'a, T>(layout: MatrixLayout<'a, T>) -> faer::MatRef<'a, T> {
     let (min_offset, max_offset) = layout_offset_bounds(&layout);
     if layout.rows > 0 && layout.cols > 0 {
-        assert!(!layout.data.is_empty(), "matrix layout requires backing storage");
+        assert!(
+            !layout.data.is_empty(),
+            "matrix layout requires backing storage"
+        );
         assert!(
             max_offset >= min_offset,
             "matrix layout offsets must be ordered"
@@ -88,7 +91,10 @@ fn faer_mat_ref<'a, T>(layout: MatrixLayout<'a, T>) -> faer::MatRef<'a, T> {
     }
 }
 
-fn matrix_layout_batch_view<'a, T>(layout: MatrixLayout<'a, T>, batch: usize) -> MatrixLayout<'a, T> {
+fn matrix_layout_batch_view<'a, T>(
+    layout: MatrixLayout<'a, T>,
+    batch: usize,
+) -> MatrixLayout<'a, T> {
     assert!(batch < layout.data.len(), "batch offset must be in bounds");
     MatrixLayout {
         data: &layout.data[batch..],
@@ -559,7 +565,14 @@ fn faer_gemm_f32_layout(a: MatrixLayout<'_, f32>, b: MatrixLayout<'_, f32>) -> V
     let a_mat = faer_mat_ref(a);
     let b_mat = faer_mat_ref(b);
     let mut c_mat = Mat::<f32>::zeros(a.rows, b.cols);
-    matmul(c_mat.as_mut(), Accum::Replace, a_mat, b_mat, 1.0f32, Par::Seq);
+    matmul(
+        c_mat.as_mut(),
+        Accum::Replace,
+        a_mat,
+        b_mat,
+        1.0f32,
+        Par::Seq,
+    );
 
     let mut c = vec![0.0f32; a.rows * b.cols];
     for j in 0..b.cols {
@@ -594,7 +607,14 @@ fn faer_gemm_f64_layout(a: MatrixLayout<'_, f64>, b: MatrixLayout<'_, f64>) -> V
     let a_mat = faer_mat_ref(a);
     let b_mat = faer_mat_ref(b);
     let mut c_mat = Mat::<f64>::zeros(a.rows, b.cols);
-    matmul(c_mat.as_mut(), Accum::Replace, a_mat, b_mat, 1.0f64, Par::Seq);
+    matmul(
+        c_mat.as_mut(),
+        Accum::Replace,
+        a_mat,
+        b_mat,
+        1.0f64,
+        Par::Seq,
+    );
 
     let mut c = vec![0.0f64; a.rows * b.cols];
     for j in 0..b.cols {

--- a/src/backend/cpu/mod.rs
+++ b/src/backend/cpu/mod.rs
@@ -10,7 +10,128 @@ use std::any::TypeId;
 #[derive(Clone, Debug, Default)]
 pub struct Cpu;
 
+#[derive(Clone, Copy)]
+pub(crate) struct MatrixLayout<'a, T> {
+    pub data: &'a [T],
+    pub rows: usize,
+    pub cols: usize,
+    pub row_stride: isize,
+    pub col_stride: isize,
+}
+
+impl<'a, T> MatrixLayout<'a, T> {
+    pub(crate) fn column_major(data: &'a [T], rows: usize, cols: usize) -> Self {
+        Self {
+            data,
+            rows,
+            cols,
+            row_stride: 1,
+            col_stride: rows as isize,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn column_major_transposed(data: &'a [T], rows: usize, cols: usize) -> Self {
+        Self {
+            data,
+            rows,
+            cols,
+            row_stride: cols as isize,
+            col_stride: 1,
+        }
+    }
+}
+
+fn layout_offset_bounds<T>(layout: &MatrixLayout<'_, T>) -> (isize, isize) {
+    let row_extent = if layout.rows == 0 {
+        0
+    } else {
+        (layout.rows as isize - 1) * layout.row_stride
+    };
+    let col_extent = if layout.cols == 0 {
+        0
+    } else {
+        (layout.cols as isize - 1) * layout.col_stride
+    };
+    let offsets = [0, row_extent, col_extent, row_extent + col_extent];
+    (
+        *offsets.iter().min().expect("offset bounds must exist"),
+        *offsets.iter().max().expect("offset bounds must exist"),
+    )
+}
+
+fn faer_mat_ref<'a, T>(layout: MatrixLayout<'a, T>) -> faer::MatRef<'a, T> {
+    let (min_offset, max_offset) = layout_offset_bounds(&layout);
+    if layout.rows > 0 && layout.cols > 0 {
+        assert!(!layout.data.is_empty(), "matrix layout requires backing storage");
+        assert!(
+            max_offset >= min_offset,
+            "matrix layout offsets must be ordered"
+        );
+        assert!(
+            ((max_offset - min_offset) as usize) < layout.data.len(),
+            "matrix layout exceeds backing storage"
+        );
+    }
+
+    let ptr = unsafe { layout.data.as_ptr().offset(-min_offset) };
+    unsafe {
+        faer::MatRef::from_raw_parts(
+            ptr,
+            layout.rows,
+            layout.cols,
+            layout.row_stride,
+            layout.col_stride,
+        )
+    }
+}
+
 impl Cpu {
+    pub(crate) fn gemm_standard_layout_internal<A: Algebra>(
+        &self,
+        a: MatrixLayout<'_, A::Scalar>,
+        b: MatrixLayout<'_, A::Scalar>,
+    ) -> Option<Vec<A::Scalar>> {
+        if TypeId::of::<A>() == TypeId::of::<Standard<f32>>() {
+            let a_f32 = MatrixLayout {
+                data: unsafe { std::mem::transmute::<&[A::Scalar], &[f32]>(a.data) },
+                rows: a.rows,
+                cols: a.cols,
+                row_stride: a.row_stride,
+                col_stride: a.col_stride,
+            };
+            let b_f32 = MatrixLayout {
+                data: unsafe { std::mem::transmute::<&[A::Scalar], &[f32]>(b.data) },
+                rows: b.rows,
+                cols: b.cols,
+                row_stride: b.row_stride,
+                col_stride: b.col_stride,
+            };
+            let result = faer_gemm_f32_layout(a_f32, b_f32);
+            return Some(unsafe { std::mem::transmute::<Vec<f32>, Vec<A::Scalar>>(result) });
+        }
+        if TypeId::of::<A>() == TypeId::of::<Standard<f64>>() {
+            let a_f64 = MatrixLayout {
+                data: unsafe { std::mem::transmute::<&[A::Scalar], &[f64]>(a.data) },
+                rows: a.rows,
+                cols: a.cols,
+                row_stride: a.row_stride,
+                col_stride: a.col_stride,
+            };
+            let b_f64 = MatrixLayout {
+                data: unsafe { std::mem::transmute::<&[A::Scalar], &[f64]>(b.data) },
+                rows: b.rows,
+                cols: b.cols,
+                row_stride: b.row_stride,
+                col_stride: b.col_stride,
+            };
+            let result = faer_gemm_f64_layout(a_f64, b_f64);
+            return Some(unsafe { std::mem::transmute::<Vec<f64>, Vec<A::Scalar>>(result) });
+        }
+
+        None
+    }
+
     /// General matrix multiplication (internal implementation).
     ///
     /// Computes C = A ⊗ B where ⊗ is the semiring multiplication
@@ -354,6 +475,23 @@ fn faer_gemm_f32(a: &[f32], m: usize, k: usize, b: &[f32], n: usize) -> Vec<f32>
     c
 }
 
+fn faer_gemm_f32_layout(a: MatrixLayout<'_, f32>, b: MatrixLayout<'_, f32>) -> Vec<f32> {
+    use faer::{linalg::matmul::matmul, Accum, Mat, Par};
+
+    let a_mat = faer_mat_ref(a);
+    let b_mat = faer_mat_ref(b);
+    let mut c_mat = Mat::<f32>::zeros(a.rows, b.cols);
+    matmul(c_mat.as_mut(), Accum::Replace, a_mat, b_mat, 1.0f32, Par::Seq);
+
+    let mut c = vec![0.0f32; a.rows * b.cols];
+    for j in 0..b.cols {
+        for i in 0..a.rows {
+            c[j * a.rows + i] = c_mat[(i, j)];
+        }
+    }
+    c
+}
+
 /// GEMM using faer for f64 (column-major layout).
 fn faer_gemm_f64(a: &[f64], m: usize, k: usize, b: &[f64], n: usize) -> Vec<f64> {
     use faer::Mat;
@@ -367,6 +505,23 @@ fn faer_gemm_f64(a: &[f64], m: usize, k: usize, b: &[f64], n: usize) -> Vec<f64>
     for j in 0..n {
         for i in 0..m {
             c[j * m + i] = c_mat[(i, j)];
+        }
+    }
+    c
+}
+
+fn faer_gemm_f64_layout(a: MatrixLayout<'_, f64>, b: MatrixLayout<'_, f64>) -> Vec<f64> {
+    use faer::{linalg::matmul::matmul, Accum, Mat, Par};
+
+    let a_mat = faer_mat_ref(a);
+    let b_mat = faer_mat_ref(b);
+    let mut c_mat = Mat::<f64>::zeros(a.rows, b.cols);
+    matmul(c_mat.as_mut(), Accum::Replace, a_mat, b_mat, 1.0f64, Par::Seq);
+
+    let mut c = vec![0.0f64; a.rows * b.cols];
+    for j in 0..b.cols {
+        for i in 0..a.rows {
+            c[j * a.rows + i] = c_mat[(i, j)];
         }
     }
     c
@@ -660,6 +815,20 @@ mod tests {
         // [1 2] × [1 2] = [1*1+2*3  1*2+2*4] = [7  10]
         // [3 4]   [3 4]   [3*1+4*3  3*2+4*4]   [15 22]
         assert_eq!(c, vec![7.0, 10.0, 15.0, 22.0]);
+    }
+
+    #[test]
+    fn test_faer_layout_gemm_accepts_rhs_transpose_view() {
+        let a = vec![1.0f32, 2.0, 3.0, 4.0];
+        let b = vec![1.0f32, 2.0, 3.0, 4.0];
+
+        let c = faer_gemm_f32_layout(
+            MatrixLayout::column_major(&a, 2, 2),
+            MatrixLayout::column_major_transposed(&b, 2, 2),
+        );
+
+        let expected = faer_gemm_f32(&a, 2, 2, &[1.0, 3.0, 2.0, 4.0], 2);
+        assert_eq!(c, expected);
     }
 
     #[cfg(feature = "tropical")]

--- a/src/einsum/engine.rs
+++ b/src/einsum/engine.rs
@@ -6,7 +6,7 @@ use omeco::{optimize_code, EinCode, GreedyMethod, Label, NestedEinsum, TreeSA};
 
 use crate::algebra::{Algebra, Scalar};
 use crate::backend::{Backend, BackendScalar};
-use crate::tensor::Tensor;
+use crate::tensor::{BinaryContractOptions, Tensor};
 
 /// Einsum specification and execution engine.
 ///
@@ -142,8 +142,18 @@ impl Einsum<usize> {
                         &self.size_dict,
                     )
                 } else {
-                    let result = self.execute_tree::<A, T, B>(tree, tensors);
-                    finalize_optimized_result::<A, T, B>(result, tree, &self.iy, &self.size_dict)
+                    let emit_final_root_output =
+                        can_emit_final_root_output(optimized_tree_output(tree), &self.iy);
+                    let result = self.execute_tree::<A, T, B>(
+                        tree,
+                        tensors,
+                        emit_final_root_output.then_some(self.iy.as_slice()),
+                    );
+                    if emit_final_root_output {
+                        result
+                    } else {
+                        finalize_optimized_result::<A, T, B>(result, tree, &self.iy, &self.size_dict)
+                    }
                 }
             }
             None => self.execute_pairwise::<A, T, B>(tensors),
@@ -195,15 +205,25 @@ impl Einsum<usize> {
                         )
                     }
                 } else {
-                    let result =
-                        self.execute_tree_with_argmax::<A, T, B>(tree, tensors, &mut argmax_cache);
-                    finalize_optimized_result_with_argmax::<A, T, B>(
-                        result,
+                    let emit_final_root_output =
+                        can_emit_final_root_output(optimized_tree_output(tree), &self.iy);
+                    let result = self.execute_tree_with_argmax::<A, T, B>(
                         tree,
-                        &self.iy,
-                        &self.size_dict,
+                        tensors,
                         &mut argmax_cache,
-                    )
+                        emit_final_root_output.then_some(self.iy.as_slice()),
+                    );
+                    if emit_final_root_output {
+                        result
+                    } else {
+                        finalize_optimized_result_with_argmax::<A, T, B>(
+                            result,
+                            tree,
+                            &self.iy,
+                            &self.size_dict,
+                            &mut argmax_cache,
+                        )
+                    }
                 }
             }
             None => self.execute_pairwise_with_argmax::<A, T, B>(tensors, &mut argmax_cache),
@@ -219,6 +239,7 @@ impl Einsum<usize> {
         tree: &NestedEinsum<usize>,
         tensors: &[&Tensor<T, B>],
         argmax_cache: &mut Vec<Tensor<u32, B>>,
+        preferred_output_indices: Option<&[usize]>,
     ) -> Tensor<T, B>
     where
         A: Algebra<Scalar = T, Index = u32>,
@@ -230,10 +251,18 @@ impl Einsum<usize> {
             NestedEinsum::Node { args, eins } => {
                 assert_eq!(args.len(), 2, "Expected binary contraction tree");
 
-                let left =
-                    self.execute_tree_with_argmax::<A, T, B>(&args[0], tensors, argmax_cache);
-                let right =
-                    self.execute_tree_with_argmax::<A, T, B>(&args[1], tensors, argmax_cache);
+                let left = self.execute_tree_with_argmax::<A, T, B>(
+                    &args[0],
+                    tensors,
+                    argmax_cache,
+                    None,
+                );
+                let right = self.execute_tree_with_argmax::<A, T, B>(
+                    &args[1],
+                    tensors,
+                    argmax_cache,
+                    None,
+                );
 
                 let ia = &eins.ixs[0];
                 let ib = &eins.ixs[1];
@@ -249,12 +278,29 @@ impl Einsum<usize> {
                 );
 
                 if A::needs_argmax() {
-                    let (result, argmax) =
-                        left.contract_binary_with_argmax::<A>(&right, &ia, &ib, iy);
+                    let (result, argmax) = if let Some(preferred_output_indices) =
+                        preferred_output_indices
+                    {
+                        let options = BinaryContractOptions {
+                            preferred_output_indices: Some(preferred_output_indices.to_vec()),
+                        };
+                        left.contract_binary_with_argmax_with_options::<A>(
+                            &right, &ia, &ib, iy, &options,
+                        )
+                    } else {
+                        left.contract_binary_with_argmax::<A>(&right, &ia, &ib, iy)
+                    };
                     argmax_cache.push(argmax);
                     result
                 } else {
-                    left.contract_binary::<A>(&right, &ia, &ib, iy)
+                    if let Some(preferred_output_indices) = preferred_output_indices {
+                        let options = BinaryContractOptions {
+                            preferred_output_indices: Some(preferred_output_indices.to_vec()),
+                        };
+                        left.contract_binary_with_options::<A>(&right, &ia, &ib, iy, &options)
+                    } else {
+                        left.contract_binary::<A>(&right, &ia, &ib, iy)
+                    }
                 }
             }
         }
@@ -353,6 +399,7 @@ impl Einsum<usize> {
         &self,
         tree: &NestedEinsum<usize>,
         tensors: &[&Tensor<T, B>],
+        preferred_output_indices: Option<&[usize]>,
     ) -> Tensor<T, B>
     where
         A: Algebra<Scalar = T, Index = u32>,
@@ -364,8 +411,8 @@ impl Einsum<usize> {
             NestedEinsum::Node { args, eins } => {
                 assert_eq!(args.len(), 2, "Expected binary contraction tree");
 
-                let left = self.execute_tree::<A, T, B>(&args[0], tensors);
-                let right = self.execute_tree::<A, T, B>(&args[1], tensors);
+                let left = self.execute_tree::<A, T, B>(&args[0], tensors, None);
+                let right = self.execute_tree::<A, T, B>(&args[1], tensors, None);
 
                 let ia = &eins.ixs[0];
                 let ib = &eins.ixs[1];
@@ -380,7 +427,14 @@ impl Einsum<usize> {
                     &self.size_dict,
                 );
 
-                left.contract_binary::<A>(&right, &ia, &ib, iy)
+                if let Some(preferred_output_indices) = preferred_output_indices {
+                    let options = BinaryContractOptions {
+                        preferred_output_indices: Some(preferred_output_indices.to_vec()),
+                    };
+                    left.contract_binary_with_options::<A>(&right, &ia, &ib, iy, &options)
+                } else {
+                    left.contract_binary::<A>(&right, &ia, &ib, iy)
+                }
             }
         }
     }
@@ -524,6 +578,18 @@ fn optimized_tree_output(tree: &NestedEinsum<usize>) -> &[usize] {
         }
         NestedEinsum::Node { eins, .. } => &eins.iy,
     }
+}
+
+fn can_emit_final_root_output(tree_output: &[usize], final_output: &[usize]) -> bool {
+    if tree_output.len() != final_output.len() {
+        return false;
+    }
+
+    let tree_set: HashSet<usize> = tree_output.iter().copied().collect();
+    let final_set: HashSet<usize> = final_output.iter().copied().collect();
+    tree_set.len() == tree_output.len()
+        && final_set.len() == final_output.len()
+        && tree_set == final_set
 }
 
 fn finalize_optimized_result<A, T, B>(
@@ -1000,6 +1066,22 @@ mod tests {
     }
 
     // Tests for helper functions
+
+    #[test]
+    fn test_root_output_plan_uses_final_order_for_pure_permutation() {
+        let tree_output = vec![2, 0, 1];
+        let final_output = vec![0, 1, 2];
+
+        assert!(can_emit_final_root_output(&tree_output, &final_output));
+    }
+
+    #[test]
+    fn test_root_output_plan_rejects_non_permutation_finalize_cases() {
+        let tree_output = vec![0, 1, 2];
+        let final_output = vec![0, 0, 2];
+
+        assert!(!can_emit_final_root_output(&tree_output, &final_output));
+    }
 
     #[test]
     fn test_linear_to_multi_empty_shape() {

--- a/src/einsum/engine.rs
+++ b/src/einsum/engine.rs
@@ -152,7 +152,12 @@ impl Einsum<usize> {
                     if emit_final_root_output {
                         result
                     } else {
-                        finalize_optimized_result::<A, T, B>(result, tree, &self.iy, &self.size_dict)
+                        finalize_optimized_result::<A, T, B>(
+                            result,
+                            tree,
+                            &self.iy,
+                            &self.size_dict,
+                        )
                     }
                 }
             }
@@ -251,18 +256,10 @@ impl Einsum<usize> {
             NestedEinsum::Node { args, eins } => {
                 assert_eq!(args.len(), 2, "Expected binary contraction tree");
 
-                let left = self.execute_tree_with_argmax::<A, T, B>(
-                    &args[0],
-                    tensors,
-                    argmax_cache,
-                    None,
-                );
-                let right = self.execute_tree_with_argmax::<A, T, B>(
-                    &args[1],
-                    tensors,
-                    argmax_cache,
-                    None,
-                );
+                let left =
+                    self.execute_tree_with_argmax::<A, T, B>(&args[0], tensors, argmax_cache, None);
+                let right =
+                    self.execute_tree_with_argmax::<A, T, B>(&args[1], tensors, argmax_cache, None);
 
                 let ia = &eins.ixs[0];
                 let ib = &eins.ixs[1];
@@ -278,29 +275,26 @@ impl Einsum<usize> {
                 );
 
                 if A::needs_argmax() {
-                    let (result, argmax) = if let Some(preferred_output_indices) =
-                        preferred_output_indices
-                    {
-                        let options = BinaryContractOptions {
-                            preferred_output_indices: Some(preferred_output_indices.to_vec()),
+                    let (result, argmax) =
+                        if let Some(preferred_output_indices) = preferred_output_indices {
+                            let options = BinaryContractOptions {
+                                preferred_output_indices: Some(preferred_output_indices.to_vec()),
+                            };
+                            left.contract_binary_with_argmax_with_options::<A>(
+                                &right, &ia, &ib, iy, &options,
+                            )
+                        } else {
+                            left.contract_binary_with_argmax::<A>(&right, &ia, &ib, iy)
                         };
-                        left.contract_binary_with_argmax_with_options::<A>(
-                            &right, &ia, &ib, iy, &options,
-                        )
-                    } else {
-                        left.contract_binary_with_argmax::<A>(&right, &ia, &ib, iy)
-                    };
                     argmax_cache.push(argmax);
                     result
+                } else if let Some(preferred_output_indices) = preferred_output_indices {
+                    let options = BinaryContractOptions {
+                        preferred_output_indices: Some(preferred_output_indices.to_vec()),
+                    };
+                    left.contract_binary_with_options::<A>(&right, &ia, &ib, iy, &options)
                 } else {
-                    if let Some(preferred_output_indices) = preferred_output_indices {
-                        let options = BinaryContractOptions {
-                            preferred_output_indices: Some(preferred_output_indices.to_vec()),
-                        };
-                        left.contract_binary_with_options::<A>(&right, &ia, &ib, iy, &options)
-                    } else {
-                        left.contract_binary::<A>(&right, &ia, &ib, iy)
-                    }
+                    left.contract_binary::<A>(&right, &ia, &ib, iy)
                 }
             }
         }

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -14,6 +14,7 @@ use crate::algebra::{Algebra, Scalar};
 use crate::backend::{Backend, Storage};
 
 pub use view::TensorView;
+pub(crate) use ops::BinaryContractOptions;
 
 /// A multi-dimensional tensor with stride-based layout.
 ///

--- a/src/tensor/mod.rs
+++ b/src/tensor/mod.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use crate::algebra::{Algebra, Scalar};
 use crate::backend::{Backend, Storage};
 
-pub use view::TensorView;
 pub(crate) use ops::BinaryContractOptions;
+pub use view::TensorView;
 
 /// A multi-dimensional tensor with stride-based layout.
 ///

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -4,6 +4,11 @@ use super::Tensor;
 use crate::algebra::{Algebra, Scalar};
 use crate::backend::{Backend, BackendScalar};
 
+#[derive(Default)]
+pub(crate) struct BinaryContractOptions {
+    pub preferred_output_indices: Option<Vec<usize>>,
+}
+
 /// Compute output shape from input shapes and modes.
 fn compute_output_shape(
     shape_a: &[usize],
@@ -73,6 +78,52 @@ impl<T: Scalar, B: Backend> Tensor<T, B> {
         (result, argmax.expect("argmax requested but not returned"))
     }
 
+    pub(crate) fn contract_binary_with_options<A: Algebra<Scalar = T, Index = u32>>(
+        &self,
+        other: &Self,
+        ia: &[usize],
+        ib: &[usize],
+        iy: &[usize],
+        options: &BinaryContractOptions,
+    ) -> Self
+    where
+        T: BackendScalar<B>,
+    {
+        let (result, _) = self.contract_binary_impl_with_options::<A>(
+            other,
+            ia,
+            ib,
+            iy,
+            false,
+            options,
+        );
+        result
+    }
+
+    pub(crate) fn contract_binary_with_argmax_with_options<
+        A: Algebra<Scalar = T, Index = u32>,
+    >(
+        &self,
+        other: &Self,
+        ia: &[usize],
+        ib: &[usize],
+        iy: &[usize],
+        options: &BinaryContractOptions,
+    ) -> (Self, Tensor<u32, B>)
+    where
+        T: BackendScalar<B>,
+    {
+        let (result, argmax) = self.contract_binary_impl_with_options::<A>(
+            other,
+            ia,
+            ib,
+            iy,
+            true,
+            options,
+        );
+        (result, argmax.expect("argmax requested but not returned"))
+    }
+
     fn contract_binary_impl<A: Algebra<Scalar = T, Index = u32>>(
         &self,
         other: &Self,
@@ -84,13 +135,50 @@ impl<T: Scalar, B: Backend> Tensor<T, B> {
     where
         T: BackendScalar<B>,
     {
+        self.contract_binary_impl_with_options::<A>(
+            other,
+            ia,
+            ib,
+            iy,
+            track_argmax,
+            &BinaryContractOptions::default(),
+        )
+    }
+
+    pub(crate) fn contract_binary_impl_with_options<A: Algebra<Scalar = T, Index = u32>>(
+        &self,
+        other: &Self,
+        ia: &[usize],
+        ib: &[usize],
+        iy: &[usize],
+        track_argmax: bool,
+        options: &BinaryContractOptions,
+    ) -> (Self, Option<Tensor<u32, B>>)
+    where
+        T: BackendScalar<B>,
+    {
         assert_eq!(ia.len(), self.ndim(), "ia length must match self.ndim()");
         assert_eq!(ib.len(), other.ndim(), "ib length must match other.ndim()");
+
+        let output_indices = options
+            .preferred_output_indices
+            .as_deref()
+            .unwrap_or(iy);
+        if let Some(preferred_output_indices) = &options.preferred_output_indices {
+            let mut preferred_sorted = preferred_output_indices.clone();
+            preferred_sorted.sort_unstable();
+            let mut output_sorted = iy.to_vec();
+            output_sorted.sort_unstable();
+            debug_assert_eq!(
+                preferred_sorted, output_sorted,
+                "preferred output indices must be a permutation of iy"
+            );
+        }
 
         // Convert usize indices to i32 modes
         let modes_a: Vec<i32> = ia.iter().map(|&i| i as i32).collect();
         let modes_b: Vec<i32> = ib.iter().map(|&i| i as i32).collect();
-        let modes_c: Vec<i32> = iy.iter().map(|&i| i as i32).collect();
+        let modes_c: Vec<i32> = output_indices.iter().map(|&i| i as i32).collect();
 
         // Compute output shape
         let shape_c =

--- a/src/tensor/ops.rs
+++ b/src/tensor/ops.rs
@@ -89,20 +89,12 @@ impl<T: Scalar, B: Backend> Tensor<T, B> {
     where
         T: BackendScalar<B>,
     {
-        let (result, _) = self.contract_binary_impl_with_options::<A>(
-            other,
-            ia,
-            ib,
-            iy,
-            false,
-            options,
-        );
+        let (result, _) =
+            self.contract_binary_impl_with_options::<A>(other, ia, ib, iy, false, options);
         result
     }
 
-    pub(crate) fn contract_binary_with_argmax_with_options<
-        A: Algebra<Scalar = T, Index = u32>,
-    >(
+    pub(crate) fn contract_binary_with_argmax_with_options<A: Algebra<Scalar = T, Index = u32>>(
         &self,
         other: &Self,
         ia: &[usize],
@@ -113,14 +105,8 @@ impl<T: Scalar, B: Backend> Tensor<T, B> {
     where
         T: BackendScalar<B>,
     {
-        let (result, argmax) = self.contract_binary_impl_with_options::<A>(
-            other,
-            ia,
-            ib,
-            iy,
-            true,
-            options,
-        );
+        let (result, argmax) =
+            self.contract_binary_impl_with_options::<A>(other, ia, ib, iy, true, options);
         (result, argmax.expect("argmax requested but not returned"))
     }
 
@@ -160,10 +146,7 @@ impl<T: Scalar, B: Backend> Tensor<T, B> {
         assert_eq!(ia.len(), self.ndim(), "ia length must match self.ndim()");
         assert_eq!(ib.len(), other.ndim(), "ib length must match other.ndim()");
 
-        let output_indices = options
-            .preferred_output_indices
-            .as_deref()
-            .unwrap_or(iy);
+        let output_indices = options.preferred_output_indices.as_deref().unwrap_or(iy);
         if let Some(preferred_output_indices) = &options.preferred_output_indices {
             let mut preferred_sorted = preferred_output_indices.clone();
             preferred_sorted.sort_unstable();

--- a/tests/suites/backend_contract.rs
+++ b/tests/suites/backend_contract.rs
@@ -67,9 +67,10 @@ fn test_cpu_contract_batched() {
     // bij,bjk->bik (batched matmul)
     let cpu = Cpu;
 
-    // 2 batches of 2x2 matrices
-    let a = vec![1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-    let b = vec![1.0, 0.0, 0.0, 1.0, 2.0, 0.0, 0.0, 2.0];
+    // Batch-major storage is column-major with the batch axis first, so the
+    // per-batch matrices are interleaved in memory.
+    let a = vec![1.0f64, 5.0, 2.0, 6.0, 3.0, 7.0, 4.0, 8.0];
+    let b = vec![1.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 2.0];
 
     let c = cpu.contract::<Standard<f64>>(
         &a,
@@ -84,9 +85,7 @@ fn test_cpu_contract_batched() {
         &[0, 1, 3],
     );
 
-    // Batch 0: identity @ [[1,2],[3,4]] = [[1,2],[3,4]]
-    // Batch 1: 2*identity @ [[5,6],[7,8]] = [[10,12],[14,16]]
-    assert_eq!(c.len(), 8);
+    assert_eq!(c, vec![1.0, 10.0, 2.0, 12.0, 3.0, 14.0, 4.0, 16.0]);
 }
 
 #[cfg(feature = "tropical")]
@@ -273,11 +272,8 @@ fn test_cpu_contract_batched_output_permuted() {
     // bij,bjk->kib (complex permutation)
     let cpu = Cpu;
 
-    // Simple 2x2x2 tensors for easy manual verification
-    // A: batch=2, i=2, j=2
-    let a = vec![1.0f64, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-    // B: batch=2, j=2, k=2 (identity matrices)
-    let b = vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0];
+    let a = vec![1.0f64, 5.0, 2.0, 6.0, 3.0, 7.0, 4.0, 8.0];
+    let b = vec![1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0];
 
     // Result should be A with axes permuted to [k, i, b]
     let c = cpu.contract::<Standard<f64>>(
@@ -293,8 +289,7 @@ fn test_cpu_contract_batched_output_permuted() {
         &[3, 1, 0], // k, i, b
     );
 
-    assert_eq!(c.len(), 8);
-    // Since B is identity, result is A with permuted axes
+    assert_eq!(c, vec![1.0, 3.0, 2.0, 4.0, 5.0, 7.0, 6.0, 8.0]);
 }
 
 // ============================================================================

--- a/tests/suites/backend_contract.rs
+++ b/tests/suites/backend_contract.rs
@@ -198,6 +198,44 @@ fn test_cpu_contract_both_strided() {
     assert_eq!(c, vec![59.0, 78.0, 83.0, 110.0]);
 }
 
+#[test]
+fn test_cpu_contract_rhs_transpose_view_matches_contiguous_rhs() {
+    let cpu = Cpu;
+
+    let a = vec![1.0f64, 2.0, 3.0, 4.0];
+    let b = vec![1.0f64, 2.0, 3.0, 4.0];
+    let b_contiguous_transpose = vec![1.0f64, 3.0, 2.0, 4.0];
+
+    let strided = cpu.contract::<Standard<f64>>(
+        &a,
+        &[2, 2],
+        &[1, 2],
+        &[0, 1],
+        &b,
+        &[2, 2],
+        &[2, 1],
+        &[1, 2],
+        &[2, 2],
+        &[0, 2],
+    );
+
+    let contiguous = cpu.contract::<Standard<f64>>(
+        &a,
+        &[2, 2],
+        &[1, 2],
+        &[0, 1],
+        &b_contiguous_transpose,
+        &[2, 2],
+        &[1, 2],
+        &[1, 2],
+        &[2, 2],
+        &[0, 2],
+    );
+
+    assert_eq!(strided, contiguous);
+    assert_eq!(strided, vec![10.0, 14.0, 14.0, 20.0]);
+}
+
 // ============================================================================
 // Tests for output permutation
 // ============================================================================


### PR DESCRIPTION
## Summary
- add layout-aware Standard GEMM fast paths for unbatched and batched CPU contractions
- reuse scratch buffers during contraction materialization and strengthen CPU/backend regression coverage
- let optimized roots emit final output order directly when finalization would only permute indices

## Test Plan
- [x] make check
- [x] targeted regression tests from the implementation plan
- [ ] cargo bench --bench binary (repo has no bench target named binary)
- [ ] make bench-network (repo has no bench-network target)
- [ ] python3 benchmarks/compare.py (benchmarks/compare.py is absent)
- [ ] samply record cargo run --release --example profile_network -- --scenario 3reg_150 --iterations 1 --output /tmp/omeinsum-profile-network-after.json (repo has no profile_network example)
