### PR TITLE
fix(cuda): refuse tropical algebras instead of silently dispatching to standard cuTENSOR (#48)

### DIFF
--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -939,6 +939,7 @@ mod tropical_guard_tests {
     }
 
     #[cfg(feature = "cuda")]
+    #[ignore = "requires CUDA GPU + cuTENSOR 2.x at runtime"]
     #[test]
     #[should_panic(expected = "issue #48")]
     fn cuda_contract_panics_on_tropical_maxplus_f64() {

--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -46,6 +46,40 @@ use std::sync::{Arc, Mutex};
 use crate::algebra::{Algebra, Scalar};
 use crate::backend::traits::{Backend, BackendScalar, Storage};
 
+/// Phase 1 guard for issue #48: detect tropical algebras and panic with a
+/// clear message instead of silently dispatching to cuTENSOR's standard
+/// `(+, ×)` kernel. The actual tropical CUDA path (via `tropical-gemm-cuda`)
+/// is a follow-up.
+///
+/// This function is a no-op for algebras that are correctly supported on the
+/// `Cuda` backend (`Standard<f32>`, `Standard<f64>`, and the `Complex32` /
+/// `Complex64` aliases).
+#[inline]
+pub(crate) fn panic_if_unsupported_tropical<A: 'static>() {
+    #[cfg(feature = "tropical")]
+    {
+        use crate::algebra::{MaxMul, MaxPlus, MinPlus};
+        use std::any::{type_name, TypeId};
+
+        let tid = TypeId::of::<A>();
+        let tropical = tid == TypeId::of::<MaxPlus<f32>>()
+            || tid == TypeId::of::<MaxPlus<f64>>()
+            || tid == TypeId::of::<MinPlus<f32>>()
+            || tid == TypeId::of::<MinPlus<f64>>()
+            || tid == TypeId::of::<MaxMul<f32>>()
+            || tid == TypeId::of::<MaxMul<f64>>();
+        assert!(
+            !tropical,
+            "Cuda backend does not yet support tropical algebra `{}`. \
+             A call with this algebra would previously have silently returned \
+             a standard `(+, ×)` result. See \
+             https://github.com/tensor4all/omeinsum-rs/issues #48 for \
+             the design tracking actual tropical-gemm-cuda integration.",
+            type_name::<A>(),
+        );
+    }
+}
+
 // ============================================================================
 // CUDA-compatible complex number wrapper
 // ============================================================================

--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -72,9 +72,9 @@ pub(crate) fn panic_if_unsupported_tropical<A: 'static>() {
             !tropical,
             "Cuda backend does not yet support tropical algebra `{}`. \
              A call with this algebra would previously have silently returned \
-             a standard `(+, ×)` result. See \
-             https://github.com/tensor4all/omeinsum-rs/issues #48 for \
-             the design tracking actual tropical-gemm-cuda integration.",
+             a standard `(+, ×)` result. See issue #48 \
+             (https://github.com/tensor4all/omeinsum-rs/issues/48) for the design \
+             tracking actual tropical-gemm-cuda integration.",
             type_name::<A>(),
         );
     }

--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -881,6 +881,9 @@ impl Backend for Cuda {
     where
         A::Scalar: BackendScalar<Self>,
     {
+        // Phase 1 (issue #48): for tropical algebras, point at the tracking
+        // issue rather than the generic cuTENSOR limitation message.
+        panic_if_unsupported_tropical::<A>();
         // cuTENSOR does not support argmax tracking.
         // This would require a custom CUDA kernel.
         panic!(
@@ -962,5 +965,32 @@ mod tropical_guard_tests {
         let sizes: HashMap<usize, usize> = [(0, 2), (1, 2), (2, 2)].into();
         let ein = Einsum::new(vec![vec![0, 1], vec![1, 2]], vec![0, 2], sizes);
         let _ = ein.execute::<MaxPlus<f64>, f64, Cuda>(&[&a, &b]);
+    }
+
+    #[cfg(feature = "cuda")]
+    #[ignore = "requires CUDA GPU + cuTENSOR 2.x at runtime"]
+    #[test]
+    #[should_panic(expected = "issue #48")]
+    fn cuda_contract_with_argmax_panics_on_tropical_maxplus_f64() {
+        use crate::einsum::Einsum;
+        use crate::tensor::Tensor;
+        use crate::{Cuda, MaxPlus};
+        use std::collections::HashMap;
+
+        let cuda = Cuda::new().expect("CUDA device required for this test");
+        let a = Tensor::<f64, Cuda>::from_data_with_backend(
+            &[1.0, 2.0, 3.0, 4.0],
+            &[2, 2],
+            cuda.clone(),
+        );
+        let b = Tensor::<f64, Cuda>::from_data_with_backend(
+            &[5.0, 6.0, 7.0, 8.0],
+            &[2, 2],
+            cuda.clone(),
+        );
+        let sizes: HashMap<usize, usize> = [(0, 2), (1, 2), (2, 2)].into();
+        let mut ein = Einsum::new(vec![vec![0, 1], vec![1, 2]], vec![0, 2], sizes);
+        ein.optimize_greedy();
+        let _ = ein.execute_with_argmax::<MaxPlus<f64>, f64, Cuda>(&[&a, &b]);
     }
 }

--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -46,16 +46,14 @@ use std::sync::{Arc, Mutex};
 use crate::algebra::{Algebra, Scalar};
 use crate::backend::traits::{Backend, BackendScalar, Storage};
 
-/// Phase 1 guard for issue #48: detect tropical algebras and panic with a
-/// clear message instead of silently dispatching to cuTENSOR's standard
-/// `(+, ×)` kernel. The actual tropical CUDA path (via `tropical-gemm-cuda`)
-/// is a follow-up.
+/// Issue #48 guard: panic on tropical algebras instead of silently
+/// dispatching them through cuTENSOR's standard `(+, ×)` kernel.
 ///
-/// This function is a no-op for algebras that are correctly supported on the
-/// `Cuda` backend (`Standard<f32>`, `Standard<f64>`, and the `Complex32` /
-/// `Complex64` aliases).
+/// Only tropical algebras are checked here. Whether other algebras are
+/// valid on the `Cuda` backend is enforced by `BackendScalar<Cuda>` on
+/// `Backend::contract`.
 #[inline]
-pub(crate) fn panic_if_unsupported_tropical<A: 'static>() {
+fn panic_if_unsupported_tropical<A: 'static>() {
     #[cfg(feature = "tropical")]
     {
         use crate::algebra::{MaxMul, MaxPlus, MinPlus};
@@ -71,8 +69,8 @@ pub(crate) fn panic_if_unsupported_tropical<A: 'static>() {
         assert!(
             !tropical,
             "Cuda backend does not yet support tropical algebra `{}`. \
-             A call with this algebra would previously have silently returned \
-             a standard `(+, ×)` result. See issue #48 \
+             Without this guard, the call would silently dispatch to the \
+             standard `(+, ×)` cuTENSOR kernel. See issue #48 \
              (https://github.com/tensor4all/omeinsum-rs/issues/48) for the design \
              tracking actual tropical-gemm-cuda integration.",
             type_name::<A>(),
@@ -794,8 +792,6 @@ impl Backend for Cuda {
     where
         A::Scalar: BackendScalar<Self>,
     {
-        // Phase 1 (issue #48): refuse tropical algebras loudly instead of
-        // silently dispatching the f32/f64 cuTENSOR standard path.
         panic_if_unsupported_tropical::<A>();
 
         // Compute output strides (column-major)
@@ -881,8 +877,6 @@ impl Backend for Cuda {
     where
         A::Scalar: BackendScalar<Self>,
     {
-        // Phase 1 (issue #48): for tropical algebras, point at the tracking
-        // issue rather than the generic cuTENSOR limitation message.
         panic_if_unsupported_tropical::<A>();
         // cuTENSOR does not support argmax tracking.
         // This would require a custom CUDA kernel.

--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -990,6 +990,8 @@ mod tropical_guard_tests {
         );
         let sizes: HashMap<usize, usize> = [(0, 2), (1, 2), (2, 2)].into();
         let mut ein = Einsum::new(vec![vec![0, 1], vec![1, 2]], vec![0, 2], sizes);
+        // Optimize so this exercises execute_tree_with_argmax (the path that
+        // tropical gradient code actually uses), not the pairwise fallback.
         ein.optimize_greedy();
         let _ = ein.execute_with_argmax::<MaxPlus<f64>, f64, Cuda>(&[&a, &b]);
     }

--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -794,6 +794,10 @@ impl Backend for Cuda {
     where
         A::Scalar: BackendScalar<Self>,
     {
+        // Phase 1 (issue #48): refuse tropical algebras loudly instead of
+        // silently dispatching the f32/f64 cuTENSOR standard path.
+        panic_if_unsupported_tropical::<A>();
+
         // Compute output strides (column-major)
         let strides_c = Self::compute_strides(shape_c);
 
@@ -932,5 +936,30 @@ mod tropical_guard_tests {
     #[should_panic(expected = "issue #48")]
     fn max_mul_f32_panics() {
         panic_if_unsupported_tropical::<MaxMul<f32>>();
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    #[should_panic(expected = "issue #48")]
+    fn cuda_contract_panics_on_tropical_maxplus_f64() {
+        use crate::einsum::Einsum;
+        use crate::tensor::Tensor;
+        use crate::{Cuda, MaxPlus};
+        use std::collections::HashMap;
+
+        let cuda = Cuda::new().expect("CUDA device required for this test");
+        let a = Tensor::<f64, Cuda>::from_data_with_backend(
+            &[1.0, 2.0, 3.0, 4.0],
+            &[2, 2],
+            cuda.clone(),
+        );
+        let b = Tensor::<f64, Cuda>::from_data_with_backend(
+            &[5.0, 6.0, 7.0, 8.0],
+            &[2, 2],
+            cuda.clone(),
+        );
+        let sizes: HashMap<usize, usize> = [(0, 2), (1, 2), (2, 2)].into();
+        let ein = Einsum::new(vec![vec![0, 1], vec![1, 2]], vec![0, 2], sizes);
+        let _ = ein.execute::<MaxPlus<f64>, f64, Cuda>(&[&a, &b]);
     }
 }

--- a/src/backend/cuda/mod.rs
+++ b/src/backend/cuda/mod.rs
@@ -852,3 +852,51 @@ impl Backend for Cuda {
         );
     }
 }
+
+#[cfg(all(test, feature = "tropical"))]
+mod tropical_guard_tests {
+    use super::*;
+    use crate::algebra::{MaxMul, MaxPlus, MinPlus, Standard};
+
+    #[test]
+    fn standard_f64_passes_guard() {
+        // Standard<f64> must NOT panic — it is the supported, correct path.
+        panic_if_unsupported_tropical::<Standard<f64>>();
+    }
+
+    #[test]
+    #[should_panic(expected = "issue #48")]
+    fn max_plus_f64_panics() {
+        panic_if_unsupported_tropical::<MaxPlus<f64>>();
+    }
+
+    #[test]
+    #[should_panic(expected = "issue #48")]
+    fn max_plus_f32_panics() {
+        panic_if_unsupported_tropical::<MaxPlus<f32>>();
+    }
+
+    #[test]
+    #[should_panic(expected = "issue #48")]
+    fn min_plus_f64_panics() {
+        panic_if_unsupported_tropical::<MinPlus<f64>>();
+    }
+
+    #[test]
+    #[should_panic(expected = "issue #48")]
+    fn min_plus_f32_panics() {
+        panic_if_unsupported_tropical::<MinPlus<f32>>();
+    }
+
+    #[test]
+    #[should_panic(expected = "issue #48")]
+    fn max_mul_f64_panics() {
+        panic_if_unsupported_tropical::<MaxMul<f64>>();
+    }
+
+    #[test]
+    #[should_panic(expected = "issue #48")]
+    fn max_mul_f32_panics() {
+        panic_if_unsupported_tropical::<MaxMul<f32>>();
+    }
+}


### PR DESCRIPTION
Closes Phase 1 of #48.

## Summary

`Cuda::contract<A>` previously dispatched solely on `TypeId::of::<A::Scalar>()`, ignoring the algebra `A` itself. For any tropical algebra over `f32` or `f64` this silently routed the call to `contract_cutensor` — cuTENSOR's standard `(+, ×)` kernel — and returned an incorrect result with no error or warning. `Cuda::contract_with_argmax` panicked with a generic "cuTENSOR does not support argmax" message that did not distinguish the tropical case.

This PR adds a `TypeId::of::<A>()`-based guard, `panic_if_unsupported_tropical<A>()`, mirroring the in-repo convention from `src/backend/cpu/mod.rs::try_tropical_gemm`. The guard fires before the existing dispatch ladder in `contract` and before the existing argmax `panic!` in `contract_with_argmax`. Tropical algebras (`MaxPlus`, `MinPlus`, `MaxMul` over `f32`/`f64`) now panic with a clear message pointing at #48. Standard / Complex paths are unchanged.

This is **Phase 1** — a safety guard, not a tropical CUDA implementation. Actual `tropical-gemm-cuda` integration (reduce-to-GEMM, GPU permute, argmax kernels) is intentionally out of scope and tracked as a follow-up on #48.

## Changes

- `src/backend/cuda/mod.rs`:
  - New free function `pub(crate) fn panic_if_unsupported_tropical<A: 'static>()` near the top of the file. Body gated by `#[cfg(feature = "tropical")]` so it's a no-op when tropical is off.
  - Guard call inserted as the first statement of `Cuda::contract` and `Cuda::contract_with_argmax`.
- Test module `tropical_guard_tests` at the bottom of the same file:
  - 7 pure-Rust unit tests for the guard helper (`Standard<f64>` no-op + six `#[should_panic]` cases covering `MaxPlus<f32/f64>`, `MinPlus<f32/f64>`, `MaxMul<f32/f64>`).
  - 2 `#[ignore]` GPU integration tests exercising the full `execute` and `execute_with_argmax` paths against a real `Cuda` device. `#[ignore]` keeps them off the default `cargo test` run so non-GPU hosts don't false-fail.

## Test plan

- [x] `cargo test --features 'cuda tropical' tropical_guard_tests` on an HKUST-GZ HPC2 A40 GPU node with CUDA 12.6 + cuTENSOR 2.6 — **7 passed; 0 failed; 2 ignored**.
- [x] Same with `-- --ignored` on the GPU node — **2 passed; 0 failed**.
- [x] `cargo test --workspace --features 'tropical parallel'` (CPU-only) — **534 passed; 0 failed**. No regression in the existing suite.
- [ ] Upstream CI: existing workflows untouched. Adding a `cargo check --features 'cuda tropical'` smoke test would require a self-hosted CUDA runner upstream does not currently configure.

## Out of scope (Phase 2)

- Implementing real tropical-gemm-cuda dispatch in `Cuda::contract` for `MaxPlus<f32/f64>`, `MinPlus<f32/f64>`, `MaxMul<f32/f64>` — reduce-to-GEMM via permute + `tropical_gemm_gpu`.
- Implementing `contract_with_argmax` for tropical algebras via `CudaKernelWithArgmax`.
- Properly wiring `tropical-gemm-cuda` into the `cuda` feature (declared in `Cargo.toml:33` but no feature gates it, so it never enters the build graph).
- Removing the orphan `pub trait CudaScalar` (`src/backend/cuda/mod.rs`, `dead_code` warning) — left in place until Phase 2 decides whether to repurpose it as the dispatch bound.